### PR TITLE
Ticket #9: Plan für Provider-Abstraktion via Plugin-System

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Provider abstraction & plugin system (#9):** the DNS provider API is now
+  hidden behind a provider-neutral `DnsProvider` interface
+  (`dnsjinja.providers`). Providers are loaded as plugins via the
+  `dnsjinja.providers` entry-point group (or an explicit `module:Class`
+  import path). Hetzner is shipped as the first plugin
+  (`dnsjinja.providers.hetzner`); the core no longer imports `hcloud`.
+- **Multiprovider support (#10):** a single `config.json` can route domains to
+  different named providers. New `global.providers` map (name → definition),
+  optional `global.default-provider`, and an optional per-domain `provider`
+  field. Each provider is queried for its zones exactly once; a failing
+  provider isolates only its own domains. Credentials per provider via
+  `token-env` (falls back to `--auth-api-token` for the single-provider case).
+
+### Changed
+- Config schema validates provider references (`default-provider` and per-domain
+  `provider` must exist in `global.providers`).
+- Offline unit tests run against an in-memory `FakeProvider` instead of mocking
+  `hcloud`; the only remaining hcloud mock is in the Hetzner-plugin test.
+
 ## [1.0.1] - 2026-06-25
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -301,7 +301,52 @@ Der Abschnitt `global` definiert die Infrastruktur-Einstellungen:
 | `zone-backups` | ja | Verzeichnis für Zone-Backups |
 | `templates` | ja | Verzeichnis für Jinja2-Templates |
 | `name-servers` | ja | Liste der Nameserver-IPs für SOA-Abfragen |
-| `dns-api-base` | nein | Basis-URL der Hetzner Cloud API (Standard: `https://api.hetzner.cloud/v1`) |
+| `dns-api-base` | nein | Basis-URL der Provider-API im Single-Provider-Modus (Standard: `https://api.hetzner.cloud/v1`) |
+| `provider` | nein | Plugin-Kennung im Single-Provider-Modus (Standard: `hetzner`) |
+| `providers` | nein | Multiprovider: benannte Provider-Definitionen (siehe unten) |
+| `default-provider` | nein | Multiprovider: Provider für Domains ohne eigenes `provider`-Feld |
+
+#### Provider-Plugins & Multiprovider
+
+Die konkrete DNS-Provider-API ist hinter einer Plugin-Schnittstelle
+abstrahiert (`dnsjinja.providers`). Ohne weitere Angaben läuft alles wie
+bisher über den eingebauten **Hetzner**-Provider.
+
+Für den Betrieb mehrerer Provider in einer Konfiguration wird `global.providers`
+gesetzt und jede Domain optional über ein `provider`-Feld geroutet:
+
+```json
+{
+  "global": {
+    "...": "...",
+    "providers": {
+      "hetzner-main": {
+        "plugin": "hetzner",
+        "api-base": "https://api.hetzner.cloud/v1",
+        "token-env": "DNSJINJA_TOKEN_HETZNER_MAIN"
+      },
+      "desec": { "plugin": "desec", "token-env": "DNSJINJA_TOKEN_DESEC" }
+    },
+    "default-provider": "hetzner-main"
+  },
+  "domains": {
+    "example.com": { "template": "standard.tpl", "provider": "desec" },
+    "example.org": { "template": "standard.tpl" }
+  }
+}
+```
+
+- `plugin` ist die Plugin-Kennung (Entry-Point `dnsjinja.providers` oder ein
+  expliziter Import-Pfad `paket.modul:Klasse`).
+- `token-env` benennt die Umgebungsvariable mit dem API-Token des Providers.
+  Ohne `token-env` wird `--auth-api-token` / `DNSJINJA_AUTH_API_TOKEN`
+  verwendet (Single-Provider-Fall).
+- Domains ohne `provider`-Feld nutzen `default-provider`.
+- Fällt ein Provider aus, werden nur dessen Domains übersprungen; die übrigen
+  Provider laufen weiter.
+
+> Hinweis: Das `registrar`-Feld (siehe unten) bezeichnet die Registrierungs-/
+> Bezahlstelle der Domain und ist **unabhängig** vom DNS-`provider`.
 
 ### Abschnitt `domains`
 
@@ -310,6 +355,7 @@ Jeder Eintrag im Abschnitt `domains` definiert eine zu verwaltende Domain. Der S
 | Feld | Pflicht | Typ | Beschreibung |
 |------|---------|-----|-------------|
 | `template` | ja | String | Jinja2-Template-Dateiname (z.B. `standard.tpl`) |
+| `provider` | nein | String | DNS-Provider-Name aus `global.providers` (Multiprovider) |
 | `mail` | nein | String | Mail-Provider (wählt `include/mail/mail_<wert>.inc`) |
 | `www` | nein | String | Web-Provider (wählt `include/www/www_<wert>.inc`) |
 | `xmpp` | nein | String | XMPP-Provider (wählt `include/xmpp/xmpp_<wert>.inc`) |
@@ -317,7 +363,7 @@ Jeder Eintrag im Abschnitt `domains` definiert eine zu verwaltende Domain. Der S
 | `subdomains` | nein | Array | Liste der Subdomains, die als eigene Zonen verarbeitet werden |
 | `custom_groups` | nein | Array | Liste gemeinsamer Konfigurationsgruppen |
 
-Die Felder `zone-id` und `zone-file` werden automatisch durch Abgleich mit der Hetzner Cloud API befüllt.
+Die Felder `zone-id` und `zone-file` werden automatisch durch Abgleich mit der jeweiligen Provider-API befüllt.
 
 Alle konfigurierten Felder werden als Jinja2-Variablen an die Templates übergeben.
 

--- a/kanban/activity.jsonl
+++ b/kanban/activity.jsonl
@@ -43,3 +43,4 @@
 {"timestamp":"2026-06-25T20:47:24.260005511+02:00","action":"release","task_id":8,"detail":"eagle-heron"}
 {"timestamp":"2026-06-25T20:47:27.010688679+02:00","action":"move","task_id":8,"detail":"in-progress -\u003e done"}
 {"timestamp":"2026-06-26T11:00:00+02:00","action":"create","task_id":9,"detail":"Provider-Abstraktion: DNS-API hinter Plugin-Schnittstelle entkoppeln"}
+{"timestamp":"2026-06-26T11:30:00+02:00","action":"create","task_id":10,"detail":"Multiprovider: Domains gleichzeitig über verschiedene DNS-Provider verwalten"}

--- a/kanban/activity.jsonl
+++ b/kanban/activity.jsonl
@@ -42,3 +42,4 @@
 {"timestamp":"2026-06-25T20:47:24.253217104+02:00","action":"edit","task_id":8,"detail":"Bug: CNAME-Apex-Ziel wird als \"@\" gesendet und von Hetzner abgelehnt"}
 {"timestamp":"2026-06-25T20:47:24.260005511+02:00","action":"release","task_id":8,"detail":"eagle-heron"}
 {"timestamp":"2026-06-25T20:47:27.010688679+02:00","action":"move","task_id":8,"detail":"in-progress -\u003e done"}
+{"timestamp":"2026-06-26T11:00:00+02:00","action":"create","task_id":9,"detail":"Provider-Abstraktion: DNS-API hinter Plugin-Schnittstelle entkoppeln"}

--- a/kanban/activity.jsonl
+++ b/kanban/activity.jsonl
@@ -46,3 +46,5 @@
 {"timestamp":"2026-06-26T11:30:00+02:00","action":"create","task_id":10,"detail":"Multiprovider: Domains gleichzeitig über verschiedene DNS-Provider verwalten"}
 {"timestamp":"2026-06-26T12:00:00+02:00","action":"create","task_id":11,"detail":"DNSSEC-Support + schrittweise DNS-Migration zu DNSSEC-fähigem Provider"}
 {"timestamp":"2026-06-26T12:30:00+02:00","action":"create","task_id":12,"detail":"deSEC-Provider-Plugin implementieren (DNSSEC-fähiges DNS-Hosting)"}
+{"timestamp":"2026-06-26T13:30:00+02:00","action":"move","task_id":9,"detail":"backlog -> done"}
+{"timestamp":"2026-06-26T13:30:00+02:00","action":"move","task_id":10,"detail":"backlog -> done"}

--- a/kanban/activity.jsonl
+++ b/kanban/activity.jsonl
@@ -45,3 +45,4 @@
 {"timestamp":"2026-06-26T11:00:00+02:00","action":"create","task_id":9,"detail":"Provider-Abstraktion: DNS-API hinter Plugin-Schnittstelle entkoppeln"}
 {"timestamp":"2026-06-26T11:30:00+02:00","action":"create","task_id":10,"detail":"Multiprovider: Domains gleichzeitig über verschiedene DNS-Provider verwalten"}
 {"timestamp":"2026-06-26T12:00:00+02:00","action":"create","task_id":11,"detail":"DNSSEC-Support + schrittweise DNS-Migration zu DNSSEC-fähigem Provider"}
+{"timestamp":"2026-06-26T12:30:00+02:00","action":"create","task_id":12,"detail":"deSEC-Provider-Plugin implementieren (DNSSEC-fähiges DNS-Hosting)"}

--- a/kanban/activity.jsonl
+++ b/kanban/activity.jsonl
@@ -44,3 +44,4 @@
 {"timestamp":"2026-06-25T20:47:27.010688679+02:00","action":"move","task_id":8,"detail":"in-progress -\u003e done"}
 {"timestamp":"2026-06-26T11:00:00+02:00","action":"create","task_id":9,"detail":"Provider-Abstraktion: DNS-API hinter Plugin-Schnittstelle entkoppeln"}
 {"timestamp":"2026-06-26T11:30:00+02:00","action":"create","task_id":10,"detail":"Multiprovider: Domains gleichzeitig über verschiedene DNS-Provider verwalten"}
+{"timestamp":"2026-06-26T12:00:00+02:00","action":"create","task_id":11,"detail":"DNSSEC-Support + schrittweise DNS-Migration zu DNSSEC-fähigem Provider"}

--- a/kanban/config.yml
+++ b/kanban/config.yml
@@ -44,4 +44,4 @@ tui:
           color: "208"
         - after: 168h
           color: "196"
-next_id: 11
+next_id: 12

--- a/kanban/config.yml
+++ b/kanban/config.yml
@@ -44,4 +44,4 @@ tui:
           color: "208"
         - after: 168h
           color: "196"
-next_id: 12
+next_id: 13

--- a/kanban/config.yml
+++ b/kanban/config.yml
@@ -44,4 +44,4 @@ tui:
           color: "208"
         - after: 168h
           color: "196"
-next_id: 10
+next_id: 11

--- a/kanban/config.yml
+++ b/kanban/config.yml
@@ -44,4 +44,4 @@ tui:
           color: "208"
         - after: 168h
           color: "196"
-next_id: 9
+next_id: 10

--- a/kanban/tasks/009-provider-abstraktion-dns-api-per-plugin-ersetzbar.md
+++ b/kanban/tasks/009-provider-abstraktion-dns-api-per-plugin-ersetzbar.md
@@ -1,0 +1,220 @@
+---
+id: 9
+title: 'Provider-Abstraktion: DNS-API hinter Plugin-Schnittstelle entkoppeln'
+status: backlog
+priority: high
+created: 2026-06-26T11:00:00+02:00
+updated: 2026-06-26T11:00:00+02:00
+tags:
+    - refactoring
+    - architecture
+    - plugin
+    - provider
+    - hetzner
+class: standard
+---
+
+## Ziel
+
+Die konkrete DNS-Provider-API (aktuell fest Hetzner Cloud via `hcloud`) so
+abstrahieren, dass `DNSJinja` nur noch gegen eine provider-neutrale
+Schnittstelle programmiert. Konkrete Provider werden als **Plugins** geladen
+und sind zur Laufzeit über Konfiguration austauschbar (z. B. Hetzner, INWX,
+deSEC, PowerDNS, Cloudflare …), ohne den Kern zu ändern.
+
+Rendering (Jinja2 + dnspython) bleibt provider-unabhängig und ist nicht
+Gegenstand des Refactorings – nur der Teil "Zonen ermitteln/anlegen, RRSets
+synchronisieren, Zonefile exportieren" wird hinter die Abstraktion gezogen.
+
+## Motivation
+
+`src/dnsjinja/dnsjinja.py` mischt zwei Verantwortlichkeiten:
+1. **Provider-neutral**: Templates rendern, SOA-Serial bilden, Zonen-Syntax
+   prüfen, gerenderte RRSets parsen, Zonefiles schreiben/backuppen.
+2. **Hetzner-spezifisch**: `hcloud.Client`, `client.zones.*`, `ZoneRecord`,
+   `hcloud.APIException`/`HCloudException`, `export_zonefile`, Hetzner-eigene
+   `protection`-Semantik, API-Endpoint-Default.
+
+Dadurch ist ein zweiter Provider heute nur per Fork/Hack möglich. Die
+Provider-Logik ist außerdem schwer isoliert testbar (Offline-Tests müssen
+`hcloud` mocken).
+
+## Inventar der Hetzner-Kopplung (Stand heute)
+
+Alles in `src/dnsjinja/dnsjinja.py`, sofern nicht anders genannt:
+
+- Importe: `import hcloud`, `from hcloud import Client`,
+  `from hcloud.zones.domain import ZoneRecord` (Z. 6–8)
+- `DEFAULT_API_BASE = "https://api.hetzner.cloud/v1"` (Z. 43)
+- `self.client = Client(token=..., api_endpoint=self._api_base)` (Z. 119)
+- `self._hetzner_zones: dict[str, Any]` (Z. 120)
+- `_prepare_zones()` (Z. 57–83): `client.zones.get_all()`,
+  `client.zones.create(name=…, mode="primary")`, `hcloud.APIException`,
+  `hcloud.HCloudException`
+- `_sync_zone_rrsets()` (Z. 224–266): `client.zones.get_rrset_all()`,
+  `ZoneRecord(value=…)`, `set_rrset_records()`, `change_rrset_ttl()`,
+  `create_rrset()`, `delete_rrset()`, `rrset.protection['change']`,
+  `hcloud.APIException`
+- `backup_zone()` (Z. 287–295): `client.zones.export_zonefile()`,
+  `hcloud.APIException`
+- `upload_zone()` (Z. 268–275): `hcloud.APIException`
+- Config-Schema `dns_api_base` Default + Pattern auf Hetzner-URL
+  (`src/dnsjinja/dnsjinja_config_schema.py`, Z. 17–21)
+- CLI-Texte/Docstrings nennen "Hetzner Cloud API" (`run()`-Docstring Z. 320,
+  `--auth-api-token`-Hilfe Z. 317)
+- Dependency `hcloud>=2.0` als harte Abhängigkeit in `pyproject.toml`
+
+## Zielarchitektur
+
+### 1. Provider-neutrale Schnittstelle
+
+Neues Modul `src/dnsjinja/providers/base.py`:
+
+- Datentypen (dataclasses, provider-neutral):
+  - `Zone(name: str, id: str, handle: Any)` – `handle` kapselt das
+    provider-eigene Objekt opak für den Kern.
+  - `RRSet(name: str, type: str, ttl: int, records: list[str],
+    protected: bool = False)`
+- Abstrakte Basis `DnsProvider` (ABC oder `typing.Protocol`) mit
+  provider-neutralen Operationen:
+  - `name: str` (Plugin-Kennung, z. B. "hetzner")
+  - `list_zones() -> dict[str, Zone]`
+  - `create_zone(name: str) -> Zone`
+  - `get_rrsets(zone: Zone) -> list[RRSet]`  (SOA wird vom Kern gefiltert)
+  - `create_rrset(zone, name, type, ttl, records: list[str]) -> None`
+  - `set_rrset_records(zone, rrset: RRSet, records: list[str]) -> None`
+  - `set_rrset_ttl(zone, rrset: RRSet, ttl: int) -> None`
+  - `delete_rrset(zone, rrset: RRSet) -> None`
+  - `export_zonefile(zone: Zone) -> str`  (optional; `ProviderCapability`
+    o. Ä. wenn ein Provider kein Zonefile-Export kann -> Backup-Skip mit
+    klarer Meldung statt Crash)
+  - `close() -> None` (optional, Ressourcenfreigabe)
+- Provider-neutrale Exceptions in `base.py`:
+  - `ProviderError(Exception)` – Basis
+  - `ProviderAuthError`, `ProviderNotFoundError`, `ProviderTransientError`
+  - Jeder Provider mappt seine nativen Fehler (z. B. `hcloud.APIException`)
+    auf diese Typen. Der Kern fängt **nur** `ProviderError`-Subtypen.
+
+Granularität bewusst auf RRSet-Operationen statt "apply(desired)": Die
+gesamte Diff-/Sync-Logik (`_sync_zone_rrsets`, Protection-Check,
+create/update/delete-Reihenfolge) bleibt provider-neutral im Kern und wird
+NICHT in jedes Plugin dupliziert. Das Plugin liefert nur die CRUD-Primitive.
+
+### 2. Plugin-Discovery
+
+Zwei kombinierbare Mechanismen:
+
+- **Entry Points** (bevorzugt, für externe Pakete): Gruppe
+  `dnsjinja.providers` in `pyproject.toml`. Laden via
+  `importlib.metadata.entry_points(group="dnsjinja.providers")`.
+  Eingebauter Hetzner-Provider wird selbst als Entry Point registriert:
+
+      [project.entry-points."dnsjinja.providers"]
+      hetzner = "dnsjinja.providers.hetzner:HetznerProvider"
+
+- **Direkter Import-Pfad** (Fallback/Override): Config-Wert
+  `provider: "my_pkg.module:MyProvider"` erlaubt das Laden ohne Entry Point.
+
+Eine `registry.py` mit `load_provider(name_or_path, *, token, api_base,
+options) -> DnsProvider` löst Name -> Klasse auf, instanziiert und liefert
+bei Unbekanntem eine klare Fehlermeldung inkl. Liste verfügbarer Provider.
+
+### 3. Konfiguration & CLI
+
+- Neuer optionaler Config-Key `global.provider` (Default: `"hetzner"` für
+  Rückwärtskompatibilität).
+- `global.provider-options` (offenes Objekt) für provider-spezifische
+  Extras, ohne Schema-Änderungen am Kern.
+- `dns-api-base` bleibt, aber das Hetzner-spezifische `^https://api.hetzner`
+  wird gelockert (nur noch `^https://`, wie bereits) bzw. in
+  Provider-Defaults verlagert; Default-Endpoint kommt künftig vom jeweiligen
+  Provider, nicht aus dem Kern (`DEFAULT_API_BASE` entfernen).
+- CLI: `--provider` (envvar `DNSJINJA_PROVIDER`) ergänzt; `--auth-api-token`
+  bleibt, Hilfetexte generalisieren ("DNS-Provider-API" statt "Hetzner Cloud
+  API"). `run()`-Docstring entschärfen.
+
+### 4. Kern-Umbau (`dnsjinja.py`)
+
+- `DNSJinja.__init__` ruft `load_provider(...)` und hält `self.provider`
+  statt `self.client`. `self._hetzner_zones` -> `self._zones: dict[str, Zone]`.
+- `_prepare_zones()` nutzt `provider.list_zones()` / `provider.create_zone()`
+  und fängt `ProviderError`.
+- `_sync_zone_rrsets()` arbeitet mit `RRSet`-Datentyp und ruft
+  `provider.get_rrsets/create_rrset/set_rrset_records/set_rrset_ttl/
+  delete_rrset`. `ZoneRecord` verschwindet aus dem Kern.
+- `backup_zone()` nutzt `provider.export_zonefile()`.
+- Hetzner-Importe komplett aus `dnsjinja.py` entfernt.
+
+### 5. Hetzner-Plugin
+
+`src/dnsjinja/providers/hetzner.py`: `HetznerProvider(DnsProvider)` kapselt
+`hcloud.Client` und implementiert das Interface 1:1 zur heutigen Logik
+(inkl. `protection['change']` -> `RRSet.protected`,
+`mode="primary"` beim Anlegen, `export_zonefile`). `hcloud` wird damit zu
+einer **optionalen** Abhängigkeit (`pyproject.toml` extras
+`[providers-hetzner]`), die nur beim Laden des Plugins importiert wird – der
+Kern bleibt importierbar ohne `hcloud`.
+
+## Refactoring-Schritte (Reihenfolge)
+
+1. `providers/base.py`: Datentypen + ABC + Exceptions (reiner Code, keine
+   Verhaltensänderung).
+2. `providers/registry.py`: Entry-Point-/Pfad-Discovery + `load_provider`.
+3. `providers/hetzner.py`: bestehende Hetzner-Aufrufe 1:1 hinter das
+   Interface ziehen; native Fehler auf `ProviderError` mappen.
+4. `dnsjinja.py` auf `self.provider` umstellen, Hetzner-Importe entfernen.
+5. Config-Schema + CLI: `provider`/`provider-options`/`--provider`,
+   `DEFAULT_API_BASE` entfernen, Hilfetexte generalisieren.
+6. `pyproject.toml`: Entry Point registrieren, `hcloud` in optionales Extra
+   verschieben (Default-Install zieht Hetzner weiter mit -> kein Breaking
+   Change für Bestandsnutzer; via `dependencies` einbinden, Extra nur für
+   die Trennung dokumentieren).
+7. Doku aktualisieren (`docs/hetzner-api.md` -> generisch + Hetzner als
+   Beispiel; README-Abschnitt "Provider/Plugins"; `AGENT.md`).
+
+## Tests
+
+- **FakeProvider** (`tests/`): In-Memory-Implementierung des Interface.
+  Damit werden Offline-Render-/Sync-Tests provider-unabhängig und brauchen
+  kein `hcloud`-Mocking mehr. Deckt create/update/delete-Diff, TTL-Change,
+  Protection-Skip, fehlende Zone, leere Zone ab.
+- **Registry-Tests**: Auflösung per Entry-Point-Name, per Import-Pfad,
+  unbekannter Provider -> klare Fehlermeldung.
+- **Hetzner-Plugin-Tests**: Mapping nativer `hcloud.APIException` ->
+  `ProviderError`; RRSet-Konvertierung (`ZoneRecord` <-> `RRSet`),
+  Protection-Flag.
+- **Regression**: bestehende `tests/test_unit.py` /
+  `tests/test_config_cases.py` müssen grün bleiben (Rendering/Parsing
+  unverändert). Integrationstests (Marker `integration`) laufen weiter gegen
+  Hetzner-Testdomain.
+
+## Rückwärtskompatibilität
+
+- Ohne `provider`-Key verhält sich alles wie heute (Default Hetzner).
+- Bestehende `config.json` und Templates bleiben unverändert gültig.
+- Default-`pip install dnsjinja-kaijen` installiert weiterhin Hetzner-Support.
+
+## Risiken / offene Punkte
+
+- Provider mit unterschiedlicher Protection-/TTL-Semantik: Interface muss
+  generisch genug sein, ohne Hetzner-Eigenheiten zu lecken.
+- Provider ohne Zonefile-Export (`backup`) sauber als "nicht unterstützt"
+  signalisieren statt Abbruch.
+- `dns-api-base`-Pattern: heutige Validierung ist Hetzner-zentriert; pro
+  Provider verlagern, ohne bestehende Configs zu brechen.
+- API-Token-Modell: andere Provider brauchen ggf. mehrere Credentials ->
+  über `provider-options` lösen, nicht über neue Top-Level-CLI-Flags.
+
+## Akzeptanzkriterien
+
+- [ ] `dnsjinja.py` importiert kein `hcloud` mehr; alle Provider-Aufrufe
+      laufen über `self.provider` (DnsProvider-Interface).
+- [ ] Ein zusätzlicher Provider kann allein durch ein Plugin-Paket
+      (Entry Point) + `provider:`-Config eingebunden werden, ohne Änderung
+      am Kern.
+- [ ] FakeProvider-basierte Offline-Tests grün; kein `hcloud`-Mock mehr im
+      Kern-Test nötig.
+- [ ] Bestehende Tests + Integrationstests weiterhin grün; Default-Verhalten
+      (Hetzner) unverändert.
+- [ ] Doku beschreibt das Plugin-/Provider-Modell und das Schreiben eines
+      eigenen Providers.

--- a/kanban/tasks/009-provider-abstraktion-dns-api-per-plugin-ersetzbar.md
+++ b/kanban/tasks/009-provider-abstraktion-dns-api-per-plugin-ersetzbar.md
@@ -1,10 +1,12 @@
 ---
 id: 9
 title: 'Provider-Abstraktion: DNS-API hinter Plugin-Schnittstelle entkoppeln'
-status: backlog
+status: done
 priority: high
 created: 2026-06-26T11:00:00+02:00
-updated: 2026-06-26T11:00:00+02:00
+updated: 2026-06-26T13:30:00+02:00
+started: 2026-06-26T13:00:00+02:00
+completed: 2026-06-26T13:30:00+02:00
 tags:
     - refactoring
     - architecture
@@ -218,3 +220,12 @@ Kern bleibt importierbar ohne `hcloud`.
       (Hetzner) unverändert.
 - [ ] Doku beschreibt das Plugin-/Provider-Modell und das Schreiben eines
       eigenen Providers.
+
+[[2026-06-26]] Fri 13:30
+Umgesetzt: providers/{base,registry,hetzner,pool}.py. DnsProvider-ABC + Zone/
+RRSet + ProviderError-Hierarchie; Registry mit Import-Pfad/Entry-Point/Builtin;
+HetznerProvider kapselt hcloud (Kern importiert kein hcloud mehr). Kern
+(dnsjinja.py) nutzt self._provider_for/self._zones. Entry-Point in pyproject
+registriert, providers-hetzner-Extra. Kern-Tests laufen über FakeProvider;
+neuer test_registry.py + test_hetzner_provider.py. Gesamte Suite grün
+(92 passed, 11 integration skipped).

--- a/kanban/tasks/010-multiprovider-domains-je-eigenem-dns-provider.md
+++ b/kanban/tasks/010-multiprovider-domains-je-eigenem-dns-provider.md
@@ -1,10 +1,12 @@
 ---
 id: 10
 title: 'Multiprovider: Domains gleichzeitig über verschiedene DNS-Provider verwalten'
-status: backlog
+status: done
 priority: high
 created: 2026-06-26T11:30:00+02:00
-updated: 2026-06-26T11:30:00+02:00
+updated: 2026-06-26T13:30:00+02:00
+started: 2026-06-26T13:00:00+02:00
+completed: 2026-06-26T13:30:00+02:00
 depends_on:
     - 9
 tags:
@@ -185,3 +187,14 @@ Neuer benannter Provider-Block plus per-Domain-Zuordnung:
       aggregiert Teilfehler korrekt.
 - [ ] Bestehende Single-Provider-Configs laufen unverändert.
 - [ ] Doku beschreibt Multiprovider-Config + Credential-Modell mit Beispiel.
+
+[[2026-06-26]] Fri 13:30
+Umgesetzt: ProviderPool (providers/pool.py) mit lazy, gecachten Instanzen pro
+benanntem Provider (token-env oder --auth-api-token). Config-Schema:
+global.providers / default-provider / domains.*.provider + Querverweis-
+Validierung. _prepare_zones gruppiert pro Provider (list_zones je Provider
+genau einmal), Warnungen provider-lokal, Fehler-Isolierung (ein Provider-
+Ausfall verwirft nur dessen Domains). upload/backup/sync routen über
+self._provider_for[domain]. Tests: tests/test_multiprovider.py (Routing,
+Gruppierung, Isolierung, zwei Accounts gleiches Plugin, Ref-Validierung).
+Rückwärtskompatibel: ohne global.providers impliziter Single-Provider.

--- a/kanban/tasks/010-multiprovider-domains-je-eigenem-dns-provider.md
+++ b/kanban/tasks/010-multiprovider-domains-je-eigenem-dns-provider.md
@@ -1,0 +1,181 @@
+---
+id: 10
+title: 'Multiprovider: Domains gleichzeitig über verschiedene DNS-Provider verwalten'
+status: backlog
+priority: high
+created: 2026-06-26T11:30:00+02:00
+updated: 2026-06-26T11:30:00+02:00
+depends_on:
+    - 9
+tags:
+    - architecture
+    - plugin
+    - provider
+    - multiprovider
+class: standard
+---
+
+## Ziel
+
+`dnsjinja` so erweitern, dass innerhalb **eines** Laufs / **einer**
+`config.json` verschiedene Domains über **verschiedene** DNS-Provider
+verwaltet werden können (z. B. Domain A bei Hetzner, Domain B bei deSEC,
+Domain C bei INWX) – jeweils mit eigenen Zugangsdaten und API-Endpunkten.
+
+Baut direkt auf **#9 (Provider-Abstraktion via Plugin)** auf. #9 macht *einen*
+Provider austauschbar; dieses Ticket macht *mehrere* Provider gleichzeitig
+nutzbar und ordnet jede Domain ihrem Provider zu.
+
+## Abgrenzung zu #9
+
+- **#9**: Ein Provider pro Lauf, hinter `DnsProvider`-Interface, per
+  Config/Plugin austauschbar. `DNSJinja` hält genau ein `self.provider`.
+- **#10 (dieses Ticket)**: N Provider pro Lauf. Routing pro Domain auf eine
+  von mehreren Provider-Instanzen; pro Provider eigene Credentials.
+
+Hard-Dependency: #10 nicht beginnen, bevor das `DnsProvider`-Interface +
+Registry aus #9 steht.
+
+## Motivation
+
+- Realität ist heterogen: Die `testdata/config/config.json` führt bereits
+  pro Domain ein `registrar`-Feld (Hetzner, Namecheap, GoDaddy …). Heute ist
+  das nur Metadaten – technisch landet trotzdem **alles** bei dem einen
+  Hetzner-Client. Multiprovider macht diese Realität abbildbar.
+- Migrationen (Domain wandert von Provider X zu Y) und gemischte Bestände
+  ohne mehrere getrennte Configs/Läufe/Tokens handhaben.
+
+## Designänderungen gegenüber dem Einzel-Provider-Modell
+
+### 1. Mehrere Provider-Instanzen statt `self.provider`
+
+- Neuer `ProviderPool` (z. B. `providers/pool.py`): hält pro **benannter
+  Provider-Konfiguration** eine instanziierte `DnsProvider`-Instanz, lazy
+  erzeugt und gecacht. Schlüssel ist der Konfig-Name (nicht der Plugin-Typ),
+  damit z. B. zwei Hetzner-Accounts mit unterschiedlichen Tokens nebeneinander
+  möglich sind.
+- `DNSJinja` hält `self.providers: ProviderPool` statt `self.provider`.
+
+### 2. Konfiguration
+
+Neuer benannter Provider-Block plus per-Domain-Zuordnung:
+
+    {
+      "global": {
+        "providers": {
+          "hetzner-main": {
+            "plugin": "hetzner",
+            "api-base": "https://api.hetzner.cloud/v1",
+            "token-env": "DNSJINJA_TOKEN_HETZNER_MAIN"
+          },
+          "desec": {
+            "plugin": "desec",
+            "token-env": "DNSJINJA_TOKEN_DESEC"
+          }
+        },
+        "default-provider": "hetzner-main"
+      },
+      "domains": {
+        "example.com":  { "template": "standard.tpl", "provider": "desec" },
+        "example.org":  { "template": "standard.tpl" }
+      }
+    }
+
+- `global.providers`: Map *Name → Provider-Definition* (`plugin` = Plugin-
+  Kennung aus #9, plus provider-spezifische Optionen / Endpoint / Credential-
+  Referenz).
+- `global.default-provider`: greift für Domains ohne explizites `provider`.
+- `domains.<name>.provider`: optionaler Verweis auf einen Namen aus
+  `global.providers`.
+- Validierung (Pydantic): jeder `domains.*.provider` und
+  `default-provider` muss in `global.providers` existieren – sonst klarer
+  Konfig-Fehler beim Start.
+
+### 3. Credentials pro Provider
+
+- Einzelnes `--auth-api-token` / `DNSJINJA_AUTH_API_TOKEN` reicht nicht mehr.
+- Pro Provider-Definition Referenz auf eine Umgebungsvariable (`token-env`)
+  oder Credential über `provider-options`. Mehrere Tokens parallel.
+- Rückwärtskompatibilität: Ist kein `global.providers` gesetzt, wird aus
+  `default-provider`/Legacy-Feldern + `--auth-api-token` implizit **ein**
+  Default-Provider "hetzner" gebildet (Verhalten wie nach #9).
+- Klare Fehlermeldung, wenn die referenzierte Token-Env fehlt – inkl.
+  Provider-Name.
+
+### 4. Routing & gruppierte Provider-Aufrufe
+
+- `_prepare_zones()` darf nicht mehr „alle Zonen von einem Client" annehmen.
+  Domains nach Provider-Instanz **gruppieren**, dann pro Provider **einmal**
+  `list_zones()` aufrufen (Effizienz, vermeidet N Einzelabfragen).
+- Der „bei Provider eingerichtet, aber nicht konfiguriert"-Hinweis aus
+  `_prepare_zones()` muss pro Provider berechnet werden (sonst falsche
+  Warnungen, weil deSEC-Zonen nicht in der Hetzner-Liste stehen).
+- `upload_zones()` / `backup_zones()` / `_sync_zone_rrsets()` routen pro
+  Domain auf `self.providers[domain]`.
+
+### 5. Fehler-Isolierung
+
+- Ein Ausfall (Auth/Netz) eines Providers darf die Domains der anderen
+  Provider **nicht** abbrechen. Pro Provider-Gruppe isoliert behandeln und am
+  Ende sammeln; Exit-Code-Logik (`exit_on_error`/254) entsprechend
+  aggregieren statt beim ersten Fehler global abzubrechen.
+
+## Refactoring-Schritte
+
+1. Config-Schema erweitern: `global.providers`, `global.default-provider`,
+   `domains.*.provider`; Querverweis-Validierung.
+2. `ProviderPool` + Credential-Auflösung (Env-Refs) implementieren.
+3. `DNSJinja.__init__`: Pool statt Einzel-Provider; jeder Domain ihre Instanz
+   zuordnen (`self._provider_for: dict[str, DnsProvider]`).
+4. `_prepare_zones()` auf Gruppierung-pro-Provider umstellen.
+5. `upload/backup/sync`-Pfade auf Per-Domain-Routing umstellen.
+6. Fehler-Isolierung + aggregierte Exit-Codes.
+7. CLI: `--auth-api-token` bleibt als Legacy-/Single-Provider-Shortcut;
+   Doku erklärt das `token-env`-Modell für Multiprovider.
+8. Doku (`README`, `docs/konfiguration.md`, `AGENT.md`): Multiprovider-Setup,
+   Beispiel-Config, Credential-Handling.
+
+## Tests
+
+- **FakeProvider** (aus #9) in **zwei Instanzen** mit unterschiedlichen
+  Zonenbeständen: Domains korrekt geroutet; keine Cross-Provider-Lecks bei
+  „konfiguriert/nicht eingerichtet"-Warnungen.
+- Config-Validierung: unbekannter `provider`-Verweis / fehlende `token-env`
+  → klarer Fehler.
+- Fehler-Isolierung: Provider A wirft `ProviderError`, Provider-B-Domains
+  werden trotzdem vollständig verarbeitet; Exit-Code spiegelt Teilfehler.
+- Effizienz/Gruppierung: `list_zones()` wird pro Provider genau einmal
+  aufgerufen (nicht pro Domain).
+- Rückwärtskompatibilität: bestehende Single-Provider-`config.json` (ohne
+  `global.providers`) läuft unverändert über den impliziten Default.
+
+## Rückwärtskompatibilität
+
+- Ohne `global.providers`/`domains.*.provider` identisches Verhalten wie nach
+  #9 (ein Hetzner-Default, `--auth-api-token`).
+- `registrar`-Feld bleibt reine Metadaten; `provider` ist das technische,
+  funktionale Feld. (Optional später: `registrar` als Default-Hinweis für
+  `provider` nutzbar – nicht Teil dieses Tickets.)
+
+## Risiken / offene Punkte
+
+- Serial-/SOA-Logik (`_new_zone_serial` via DNS-Resolver) ist provider-
+  unabhängig und bleibt – prüfen, dass Multiprovider daran nichts ändert.
+- Provider mit/ohne Zonefile-Export gemischt: Backup pro Domain nach
+  Capability des jeweiligen Providers entscheiden (siehe #9).
+- Parallelisierung pro Provider (Performance) bewusst **out of scope** –
+  erst korrektes serielles Routing, Optimierung später.
+- Secrets: nur Env-Referenzen in der Config, keine Klartext-Tokens.
+
+## Akzeptanzkriterien
+
+- [ ] Eine `config.json` kann Domains auf mehrere benannte Provider verteilen;
+      jede Domain wird über ihre Provider-Instanz verwaltet.
+- [ ] Pro Provider eigene Credentials (getrennte Token-Envs), inkl. zweier
+      Accounts desselben Plugins.
+- [ ] `list_zones()` wird pro Provider einmal aufgerufen; „nicht
+      konfiguriert"-Warnungen sind provider-lokal korrekt.
+- [ ] Ein Provider-Ausfall isoliert die übrigen Provider nicht; Exit-Code
+      aggregiert Teilfehler korrekt.
+- [ ] Bestehende Single-Provider-Configs laufen unverändert.
+- [ ] Doku beschreibt Multiprovider-Config + Credential-Modell mit Beispiel.

--- a/kanban/tasks/010-multiprovider-domains-je-eigenem-dns-provider.md
+++ b/kanban/tasks/010-multiprovider-domains-je-eigenem-dns-provider.md
@@ -38,12 +38,16 @@ Registry aus #9 steht.
 
 ## Motivation
 
-- Realität ist heterogen: Die `testdata/config/config.json` führt bereits
-  pro Domain ein `registrar`-Feld (Hetzner, Namecheap, GoDaddy …). Heute ist
-  das nur Metadaten – technisch landet trotzdem **alles** bei dem einen
-  Hetzner-Client. Multiprovider macht diese Realität abbildbar.
-- Migrationen (Domain wandert von Provider X zu Y) und gemischte Bestände
-  ohne mehrere getrennte Configs/Läufe/Tokens handhaben.
+- **Wichtig – `registrar` ≠ DNS-Provider:** Das `registrar`-Feld in
+  `testdata/config/config.json` (Hetzner, Namecheap, GoDaddy …) bezeichnet,
+  **wo die Domain registriert/bezahlt** wird, NICHT wo das DNS gehostet wird.
+  Beides ist orthogonal (Domain bei Namecheap registriert, DNS bei Hetzner).
+  Aktuell liegt das **DNS aller Domains bei Hetzner**; `registrar` ist davon
+  unabhängig. Multiprovider trennt genau diese Achse: das DNS-Hosting wird
+  pro Domain wählbar, unabhängig vom Registrar.
+- Konkreter Anlass (siehe #11): schrittweise DNS-Migration von Hetzner zu
+  einem DNSSEC-fähigen DNS-Provider – Domain für Domain, ohne mehrere
+  getrennte Configs/Läufe/Tokens.
 
 ## Designänderungen gegenüber dem Einzel-Provider-Modell
 
@@ -153,9 +157,11 @@ Neuer benannter Provider-Block plus per-Domain-Zuordnung:
 
 - Ohne `global.providers`/`domains.*.provider` identisches Verhalten wie nach
   #9 (ein Hetzner-Default, `--auth-api-token`).
-- `registrar`-Feld bleibt reine Metadaten; `provider` ist das technische,
-  funktionale Feld. (Optional später: `registrar` als Default-Hinweis für
-  `provider` nutzbar – nicht Teil dieses Tickets.)
+- `registrar` (Bezahl-/Registrierungsstelle) und `provider` (DNS-Hosting)
+  sind orthogonal und werden NICHT verknüpft. `registrar` bleibt reine
+  Metadaten; `provider` ist das technische, funktionale Feld für das
+  DNS-Routing. `registrar` taugt ausdrücklich NICHT als Default für
+  `provider`.
 
 ## Risiken / offene Punkte
 

--- a/kanban/tasks/011-dnssec-support-und-schrittweise-migration.md
+++ b/kanban/tasks/011-dnssec-support-und-schrittweise-migration.md
@@ -1,0 +1,168 @@
+---
+id: 11
+title: 'DNSSEC-Support + schrittweise DNS-Migration zu DNSSEC-fähigem Provider'
+status: backlog
+priority: high
+created: 2026-06-26T12:00:00+02:00
+updated: 2026-06-26T12:00:00+02:00
+depends_on:
+    - 9
+    - 10
+tags:
+    - dnssec
+    - migration
+    - provider
+    - architecture
+class: standard
+---
+
+## Ziel & Kontext
+
+Aktuell liegt das **DNS aller Domains bei Hetzner** (kein/ungewünschtes
+DNSSEC). Ziel ist die **schrittweise** Migration des DNS-Hostings – Domain
+für Domain – zu einem **DNSSEC-fähigen** DNS-Provider, ohne Big-Bang und mit
+jederzeit klarem, zurückrollbarem Zustand.
+
+Wichtig: Die **Registrierung** (Feld `registrar`, wo die Domain bezahlt wird)
+bleibt unverändert. Migriert wird nur das **DNS-Hosting** (`provider` aus
+#10). Beim Registrar ändern sich pro Domain nur zwei Dinge: die delegierten
+**NS-Records** und der **DS-Record** (DNSSEC-Vertrauensanker).
+
+Abhängigkeiten:
+- **#9** liefert das Provider-Interface (DNS-API hinter Plugin).
+- **#10** liefert Multiprovider/Per-Domain-Routing – die technische
+  Voraussetzung, um *einzelne* Domains auf den neuen Provider zu schieben,
+  während der Rest noch bei Hetzner bleibt.
+Dieses Ticket ergänzt die **DNSSEC-Dimension** + den **Migrations-Workflow**.
+
+## Teil A – DNSSEC im Provider-Modell
+
+### A1. Capability-Flag
+
+`DnsProvider` (aus #9) um Capability erweitern, z. B.
+`supports_dnssec: bool` bzw. eine `capabilities`-Menge. Kern und Migrations-
+Tooling können so prüfen, ob ein Zielprovider DNSSEC kann.
+
+### A2. Sync darf signaturverwaltete RRSets NICHT anfassen
+
+`_sync_zone_rrsets()` löscht heute „stale" RRSets, die nicht im gerenderten
+Zustand stehen. SOA wird bereits ausgenommen. Bei DNSSEC **provider-
+verwaltete** Typen MÜSSEN ebenfalls ausgenommen werden, sonst löscht/zerstört
+der Sync die Signatur-Infrastruktur:
+
+- Ausschlussliste erweitern um: `DNSKEY`, `RRSIG`, `NSEC`, `NSEC3`,
+  `NSEC3PARAM`, `CDS`, `CDNSKEY` (und `SOA` wie bisher).
+- Diese Records werden vom signierenden Provider automatisch erzeugt; der
+  gerenderte Zonentext enthält sie nicht → ohne Ausschluss würde der
+  Delete-Pass sie als „verwaist" entfernen wollen.
+- Test: Zone beim (Fake-)Provider hat DNSKEY/RRSIG; Sync lässt sie unberührt.
+
+### A3. DS-/Schlüssel-Material auslesbar machen
+
+Neue (optionale) Interface-Methode, z. B.
+`get_dnssec_ds(zone) -> list[DS]` / `get_dnssec_keys(zone)`, damit nach
+Aktivierung am neuen Provider der **DS-Record** für den Registrar ermittelt
+werden kann. Provider, die kein DNSSEC können, geben „nicht unterstützt"
+zurück (analog Zonefile-Export-Capability in #9).
+
+### A4. Grenze zum Registrar
+
+Das **Publizieren** von DS- und NS-Änderungen passiert beim **Registrar**
+(eigene API oder manuell) – nicht in der DNS-Provider-API. Dieses Ticket:
+- stellt den DS-Wert maschinenlesbar bereit (Ausgabe/Report),
+- dokumentiert den manuellen/registrar-seitigen Schritt klar.
+Eine Registrar-API-Anbindung (automatisches DS/NS-Setzen) ist **out of
+scope** (eigenes Folge-Ticket; einige Registrare inkl. Hetzner bieten APIs).
+
+## Teil B – Migrations-Workflow (pro Domain)
+
+Sollzustand-Runbook, das das Tooling unterstützen soll:
+
+1. **Zielzone anlegen**: Domain in `config.json` auf neuen `provider` (#10)
+   zeigen lassen; Records dorthin rendern/syncen (`-u`). Hetzner bleibt
+   parallel aktiv.
+2. **Parität prüfen** (NEU, siehe B1): Records am neuen Provider == bisheriger
+   Stand? Erst weiter, wenn deckungsgleich.
+3. **DNSSEC aktivieren** am neuen Provider (oft automatisch, z. B. deSEC
+   signiert by default) und **DS auslesen** (A3).
+4. **Registrar**: NS auf die Nameserver des neuen Providers umstellen; nach
+   Propagation **DS** publizieren (A4).
+5. **Verifizieren**: Auflösung über neue NS korrekt, DNSSEC-Validierung grün
+   (AD-Bit), Serial konsistent.
+6. **Hetzner-Zone stilllegen** (Backup vorher via #9-Export, sofern Provider
+   das kann) und aus dem Hetzner-Routing nehmen.
+
+Reihenfolge ist bewusst reversibel: bis Schritt 4 (NS/DS) ist der alte Stand
+unverändert autoritativ.
+
+### B1. Paritäts-/Diff-Modus (neues Feature)
+
+Read-only-Vergleich, der vor dem NS-Cutover Vertrauen schafft:
+- Vergleicht gerenderte Soll-RRSets bzw. die Zone des Alt-Providers gegen die
+  Zone des Ziel-Providers und meldet Abweichungen (fehlende/zusätzliche/
+  abweichende RRSets), DNSSEC-Typen dabei ausgenommen (A2).
+- Als CLI-Modus, z. B. `--diff` / `--verify-parity` (analog `--dry-run`),
+  über das Provider-Interface – provider-neutral.
+
+### B2. Serial-/SOA-Ermittlung während der Migration
+
+Stolperstein: `_get_zone_serial()` / `_new_zone_serial()` lesen den SOA-Serial
+über die **global** konfigurierten `name-servers` (Resolver). Während der
+Migration ist die autoritative Quelle einer Domain provider-abhängig:
+- Eine schon migrierte Domain über die alten (Hetzner-)NS abzufragen liefert
+  veraltete/keine Daten → falscher/abbrechender Serial.
+- Lösung: SOA-Serial **pro Domain** an der richtigen Quelle ermitteln –
+  bevorzugt direkt beim zuständigen Provider (Interface) bzw. über die für
+  die Domain zuständigen NS, statt global fixer Resolver.
+- Test deckt: migrierte vs. nicht-migrierte Domain liefern je korrekten
+  Serial.
+
+## Zielprovider-Kandidaten (offen)
+
+Provider-neutral umsetzen; konkretes erstes DNSSEC-Plugin ist zu wählen.
+Kandidaten u. a. **deSEC** (DNSSEC by default, freie API, DS via API – guter
+Startkandidat), Cloudflare, INWX, PowerDNS. → Klärung mit Nutzer, welches
+Plugin zuerst gebaut wird (eigenes Plugin-Ticket nach #9).
+
+## Tests
+
+- A2: Sync lässt DNSKEY/RRSIG/NSEC*/CDS/CDNSKEY am Provider unberührt
+  (FakeProvider mit vorhandenen Signatur-RRSets).
+- A3: DS/Schlüssel auslesbar; Provider ohne DNSSEC meldet „nicht
+  unterstützt" sauber.
+- B1: Diff-Modus erkennt fehlende/zusätzliche/abweichende RRSets; ignoriert
+  DNSSEC-Typen; läuft read-only.
+- B2: Per-Domain-Serial korrekt für migrierte und nicht-migrierte Domain.
+- Migrations-Smoke (mit FakeProvidern „hetzner" + „desec"): eine Domain
+  wechselt `provider`, Parität grün, DS abrufbar, Alt-Zone bleibt bis Cutover
+  unangetastet.
+
+## Rückwärtskompatibilität
+
+- Ohne DNSSEC-Provider / ohne Migration ändert sich nichts am Verhalten.
+- A2 (Ausschluss der Signatur-Typen) ist auch ohne aktive Migration korrekt
+  und schadet bestehenden Hetzner-Zonen nicht.
+
+## Risiken / offene Punkte
+
+- DS-Timing: DS erst publizieren, wenn DNSKEY am neuen Provider live & NS
+  umgestellt – sonst Validierungs-Bruch (SERVFAIL). Runbook muss die
+  Reihenfolge betonen.
+- Unterschiedliche DNSSEC-Modelle der Provider (managed signing vs.
+  CDS/CDNSKEY-Automatik nach RFC 7344/8078) – Interface generisch halten.
+- TTL-Absenkung vor Cutover (NS/SOA) zur schnelleren Propagation –
+  Runbook-Hinweis.
+- Registrar-Schritt bleibt teils manuell (out of scope, siehe A4).
+
+## Akzeptanzkriterien
+
+- [ ] `_sync_zone_rrsets()` fasst SOA + DNSSEC-Typen (DNSKEY, RRSIG, NSEC,
+      NSEC3, NSEC3PARAM, CDS, CDNSKEY) nicht an; durch Test abgesichert.
+- [ ] Provider-Interface meldet DNSSEC-Capability und liefert DS-/Schlüssel-
+      Material (sofern unterstützt).
+- [ ] Paritäts-/Diff-Modus vergleicht Ziel-Provider gegen Soll/Alt-Provider
+      read-only und ist provider-neutral.
+- [ ] SOA-Serial wird pro Domain an der korrekten autoritativen Quelle
+      ermittelt (migrierte und nicht-migrierte Domain korrekt).
+- [ ] Migrations-Runbook (Domain für Domain, reversibel bis NS/DS-Cutover)
+      dokumentiert; Registrar-Schritt klar als manuell/Folge-Ticket markiert.

--- a/kanban/tasks/012-desec-provider-plugin-implementieren.md
+++ b/kanban/tasks/012-desec-provider-plugin-implementieren.md
@@ -1,0 +1,150 @@
+---
+id: 12
+title: 'deSEC-Provider-Plugin implementieren (DNSSEC-fähiges DNS-Hosting)'
+status: backlog
+priority: high
+created: 2026-06-26T12:30:00+02:00
+updated: 2026-06-26T12:30:00+02:00
+depends_on:
+    - 9
+tags:
+    - plugin
+    - provider
+    - desec
+    - dnssec
+    - http
+class: standard
+---
+
+## Ziel
+
+Ein `DnsProvider`-Plugin für **deSEC** (desec.io) implementieren –
+`src/dnsjinja/providers/desec.py`, `DesecProvider(DnsProvider)`. deSEC ist
+der angepeilte DNSSEC-fähige DNS-Provider für die schrittweise Migration weg
+von Hetzner. Das Plugin erfüllt das Interface aus **#9**, ist über die
+Registry/Entry-Points ladbar und im Multiprovider-Betrieb (**#10**) parallel
+zu Hetzner nutzbar.
+
+## Abhängigkeiten
+
+- **#9** (Provider-Interface + Registry): Hard-Dependency – ohne `DnsProvider`,
+  `Zone`, `RRSet`, `ProviderError` und `load_provider` nicht umsetzbar.
+- **#10**: ermöglicht den parallelen Betrieb deSEC + Hetzner; nicht zwingend
+  für die reine Plugin-Implementierung, aber Zielkontext.
+- **#11**: liefert die DNSSEC-Erweiterungen am Interface (`supports_dnssec`,
+  `get_dnssec_ds`, Schutz der Signatur-RRSets). Die DNSSEC-spezifischen
+  Methoden dieses Plugins (DS-Abruf) hängen an A1/A3 aus #11.
+
+> Hinweis: Alle u. g. API-Details gegen die **aktuelle** deSEC-API-Doku
+> (https://desec.readthedocs.io) verifizieren, bevor implementiert wird.
+
+## deSEC-API – relevante Eckpunkte
+
+- **Base-URL**: `https://desec.io/api/v1/`
+- **Auth**: Token, Header `Authorization: Token <token>`. Über
+  `provider-options`/`token-env` aus #10 (kein Bearer wie bei Hetzner).
+- **Domains/Zonen**:
+  - `GET /domains/` (Liste, **cursor-paginiert** via `Link`-Header – Folgen!)
+  - `POST /domains/` Body `{"name": "<zone>"}` (deSEC kennt kein
+    `mode="primary"` wie Hetzner)
+  - `GET /domains/{name}/` – enthält `keys` (DNSSEC: `ds[]`, `dnskey`)
+  - `DELETE /domains/{name}/`
+- **RRSets**: `GET/POST /domains/{name}/rrsets/`,
+  Einzel-RRSet `…/rrsets/{subname}/{type}/` (GET/PATCH/PUT/DELETE):
+  - Felder: `subname`, `type`, `ttl`, `records: list[str]`.
+  - **Löschen** = `DELETE` der RRSet **oder** `records: []` setzen.
+  - **Bulk** über `PATCH`/`PUT` auf `…/rrsets/` mit Array (effizienter als
+    N Einzelcalls – siehe Mapping-Strategie unten).
+- **DNSSEC**: deSEC **signiert automatisch** (immer an, nicht abschaltbar) →
+  `supports_dnssec = True`; DS kommt aus `domain.keys[].ds`.
+
+## Mapping deSEC ↔ dnsjinja-Kernmodell
+
+| Kern (#9 `RRSet`)        | deSEC                                   |
+|--------------------------|-----------------------------------------|
+| `name` = `@` (Apex)      | `subname = ""` (leerer String)          |
+| `name` = `www`           | `subname = "www"`                       |
+| `records` (FQDN, Punkt)  | `records` (Presentation, FQDN m. Punkt) |
+| `ttl`                    | `ttl` (Achtung Mindest-TTL, s. u.)      |
+
+- **Apex-Mapping** `@` ↔ `""` ist der wichtigste Stolperstein. dnsjinja-Kern
+  nutzt seit #8 `@` als Owner und FQDN-Ziele mit Punkt (`relativize=False`) –
+  das passt gut zu deSECs Presentation-Format; nur `subname` muss übersetzt
+  werden.
+- **Mindest-TTL**: deSEC erzwingt eine Konto-/Domain-`minimum_ttl` (oft
+  3600). TTLs unterhalb werden mit `400` abgelehnt. Plugin muss das als
+  klaren `ProviderError` mit verständlicher Meldung mappen (nicht roher
+  HTTP-Fehler) – ggf. Hinweis „Template-TTL < deSEC-Minimum".
+
+## Interface-Implementierung (`DesecProvider`)
+
+- `name = "desec"`, `supports_dnssec = True`.
+- `list_zones()` → paginierte `GET /domains/`, Map `name -> Zone(handle=…)`.
+- `create_zone(name)` → `POST /domains/`.
+- `get_rrsets(zone)` → paginierte RRSet-Liste → `list[RRSet]`; `subname=""`
+  zurück auf `@` mappen. SOA/DNSSEC-Typen liefert deSEC i. d. R. ohnehin nicht
+  als editierbare RRSets, der Kern filtert zusätzlich (siehe #11 A2).
+- `create_rrset` / `set_rrset_records` / `set_rrset_ttl` / `delete_rrset`
+  über die RRSet-Endpunkte. **Empfohlen**: in `_sync_zone_rrsets` (Kern) bleibt
+  die Diff-Logik; das Plugin kann zur Effizienz intern Bulk-`PATCH` nutzen,
+  muss aber die Einzelmethoden-Semantik des Interface erfüllen.
+- `export_zonefile(zone)` → deSEC bietet **keinen** nativen Zonefile-Export.
+  Optionen: (a) Capability „nicht unterstützt" melden (Backup-Skip wie in #9),
+  oder (b) Zonefile aus den RRSets **synthetisieren**. Entscheidung im Ticket:
+  zunächst (a) sauber melden; (b) optional als Folgeschritt.
+- `get_dnssec_ds(zone)` (aus #11 A3) → aus `GET /domains/{name}/` `keys[].ds`.
+
+## Fehler-Mapping
+
+Native HTTP-Fehler → `ProviderError`-Hierarchie aus #9:
+- `401/403` → `ProviderAuthError`
+- `404` → `ProviderNotFoundError`
+- `429` (Throttling, `Retry-After`) → `ProviderTransientError` (mit Backoff;
+  deSEC rate-limited spürbar)
+- `400` (z. B. TTL/Validierung) → `ProviderError` mit deSEC-Fehlertext
+- `5xx`/Netzfehler → `ProviderTransientError`
+
+## Abhängigkeiten / Packaging
+
+- HTTP-Client: deSEC hat keinen offiziellen Python-SDK in den Deps. Direkt
+  über `httpx` (bevorzugt) oder `requests`. Als **optionales** Extra
+  einbinden (`[project.optional-dependencies] providers-desec`), analog zur
+  hcloud-Trennung in #9 – der Kern bleibt importierbar ohne deSEC-Deps.
+- Entry-Point registrieren:
+
+      [project.entry-points."dnsjinja.providers"]
+      desec = "dnsjinja.providers.desec:DesecProvider"
+
+## Tests
+
+- **Mit gemocktem HTTP** (respx/responses o. Ä.), keine Live-Calls in den
+  Unit-Tests:
+  - Pagination über mehrere Seiten korrekt zusammengeführt.
+  - Apex-Mapping `@` ↔ `subname=""` in beide Richtungen.
+  - CRUD: create/set-records/set-ttl/delete erzeugen die richtigen Requests.
+  - Fehler-Mapping: 401/404/429/400 → richtige `ProviderError`-Subtypen;
+    429 respektiert `Retry-After`.
+  - Mindest-TTL: TTL < Minimum → verständlicher `ProviderError`.
+  - `get_dnssec_ds` parst `keys[].ds`.
+- **Registry**: `load_provider("desec")` instanziiert `DesecProvider`.
+- **FakeProvider-Parität**: deSEC-Plugin erfüllt dieselben Interface-Kontrakte
+  wie der FakeProvider (gemeinsame Contract-Tests, falls in #9 vorhanden).
+- **Integrationstest** (Marker `integration`, optional): gegen eine echte
+  deSEC-Testdomain mit eigenem Token (`DNSJINJA_TOKEN_DESEC`), analog zu den
+  bestehenden Hetzner-Integrationstests. Standardmäßig übersprungen.
+
+## Akzeptanzkriterien
+
+- [ ] `DesecProvider` erfüllt das `DnsProvider`-Interface aus #9 und ist über
+      Entry-Point/Registry als `"desec"` ladbar.
+- [ ] Apex (`@` ↔ `""`), FQDN-Records und TTL korrekt gemappt; Pagination
+      vollständig gefolgt.
+- [ ] HTTP-Fehler sauber auf `ProviderError`-Subtypen gemappt (inkl.
+      429/Retry-After und Mindest-TTL-Fall).
+- [ ] `supports_dnssec = True`; DS über `get_dnssec_ds` abrufbar (#11 A3).
+- [ ] `export_zonefile` meldet „nicht unterstützt" sauber (Backup-Skip) –
+      kein Crash.
+- [ ] `httpx`/Client als optionales Extra; Kern bleibt ohne deSEC-Deps
+      importierbar.
+- [ ] Unit-Tests mit gemocktem HTTP grün; optionaler Integrationstest
+      vorhanden und standardmäßig übersprungen.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,12 @@ dependencies = [
 [project.optional-dependencies]
 test = ["pytest"]
 docs = ["mkdocs-material>=9.5", "mike>=2.1"]
+# Hetzner-Plugin-Abhängigkeit. hcloud bleibt vorerst auch in [dependencies],
+# damit Default-Installationen den Hetzner-Provider weiterhin mitbringen.
+providers-hetzner = ["hcloud>=2.0"]
+
+[project.entry-points."dnsjinja.providers"]
+hetzner = "dnsjinja.providers.hetzner:HetznerProvider"
 
 [project.urls]
 Homepage = "https://github.com/kaijen/dnsjinja"

--- a/src/dnsjinja/dnsjinja.py
+++ b/src/dnsjinja/dnsjinja.py
@@ -3,9 +3,6 @@ from socket import gethostbyname
 from pathlib import Path
 from datetime import datetime, timezone
 from typing import Any, Required, TypedDict
-import hcloud
-from hcloud import Client
-from hcloud.zones.domain import ZoneRecord
 import json
 import logging
 import os
@@ -21,6 +18,7 @@ import pydantic
 import tempfile
 from .myloadenv import load_env
 from .dnsjinja_config_schema import DnsJinjaConfig as _DnsJinjaConfigModel
+from .providers import DnsProvider, ProviderError, ProviderPool, Zone
 
 logger = logging.getLogger(__name__)
 
@@ -30,6 +28,7 @@ _TEMPLATE_NAME_RE = re.compile(r'^[a-zA-Z0-9._-]+$')
 class DomainConfigEntry(TypedDict, total=False):
     """Laufzeit-Struktur eines Domain-Eintrags in self.config['domains']."""
     template: Required[str]   # aus config.json
+    provider: str             # optionaler Provider-Name (Multiprovider, #10)
     zone_file: str            # gesetzt von _prepare_zones() als 'zone-file'
     zone_id: str              # gesetzt von _prepare_zones() als 'zone-id'
 
@@ -40,7 +39,9 @@ class UploadError(Exception):
 
 class DNSJinja:
 
-    DEFAULT_API_BASE = "https://api.hetzner.cloud/v1"
+    #: Record-Typen, die nicht über den RRSet-Sync verwaltet werden
+    #: (SOA wird vom Provider gepflegt). DNSSEC-Typen kommen mit #11 hinzu.
+    SYNC_EXCLUDE_TYPES = frozenset({'SOA'})
 
     @staticmethod
     def _check_path(path: str, basedir: str, typ: str, expect: str = 'dir') -> Path:
@@ -54,33 +55,88 @@ class DNSJinja:
             sys.exit(1)
         return p
 
-    def _prepare_zones(self) -> None:
-        try:
-            all_zones = self.client.zones.get_all()
+    def _build_provider_pool(self) -> str:
+        """Provider-Definitionen aus der Config ableiten und Pool aufbauen.
 
-            hetzner_zones = {z.name: z for z in all_zones}
-            config_domains = set(self.config['domains'].keys())
-            for d in sorted(config_domains - hetzner_zones.keys()):
+        Liefert den Namen des Default-Providers zurück. Unterstützt zwei
+        Modi:
+
+        * **Multiprovider (#10):** ``global.providers`` (Name -> Definition)
+          plus optional ``global.default-provider``; pro Domain ein optionales
+          ``provider``-Feld.
+        * **Single-Provider/Legacy (#9):** ohne ``global.providers`` wird ein
+          impliziter Provider ``"default"`` aus ``global.provider`` (Default
+          ``hetzner``), ``global.dns-api-base`` und ``--auth-api-token``
+          gebildet – Verhalten wie bisher.
+        """
+        gcfg = self.config['global']
+        providers_cfg = gcfg.get('providers')
+
+        if providers_cfg:
+            definitions: dict[str, dict] = {name: dict(defn) for name, defn in providers_cfg.items()}
+            default_provider = gcfg.get('default-provider')
+            if not default_provider and len(definitions) == 1:
+                default_provider = next(iter(definitions))
+            # Bei mehreren Providern ohne Default ist per Schema garantiert, dass
+            # jede Domain ein explizites provider-Feld hat (default bleibt None).
+        else:
+            if not self.auth_api_token:
+                click.echo('Kein API-Token angegeben. Bitte --auth-api-token oder DNSJINJA_AUTH_API_TOKEN setzen.')
+                sys.exit(1)
+            defn = {'plugin': gcfg.get('provider', 'hetzner')}
+            api_base = gcfg.get('dns-api-base')
+            if api_base:
+                defn['api-base'] = api_base
+            definitions = {'default': defn}
+            default_provider = 'default'
+
+        self.providers = ProviderPool(definitions, default_token=self.auth_api_token)
+        return default_provider
+
+    def _prepare_zones(self) -> None:
+        """Domains nach Provider gruppieren und je Provider einmal abgleichen.
+
+        Pro Provider werden die Zonen genau einmal ermittelt; die
+        ``konfiguriert/eingerichtet``-Hinweise sind dadurch provider-lokal
+        korrekt. Fällt ein Provider aus, werden nur dessen Domains ignoriert –
+        die übrigen Provider laufen weiter (Fehler-Isolierung, #10).
+        """
+        by_provider: dict[str, list[str]] = {}
+        for d in self.config['domains']:
+            by_provider.setdefault(self._provider_name_for[d], []).append(d)
+
+        for pname, domains in by_provider.items():
+            try:
+                provider = self.providers.get(pname)
+                zones = provider.list_zones()
+            except ProviderError as e:
+                click.echo(f"Provider {pname!r} nicht verfügbar: {e} – betroffene Domains werden ignoriert")
+                for d in domains:
+                    del self.config['domains'][d]
+                continue
+
+            configured = set(domains)
+            for d in sorted(configured - zones.keys()):
                 if self._create_missing:
                     try:
-                        response = self.client.zones.create(name=d, mode="primary")
-                        hetzner_zones[d] = response.zone
-                        click.echo(f'{d} wurde neu bei Hetzner angelegt')
-                    except hcloud.APIException as e:
-                        click.echo(f'{d} konnte bei Hetzner nicht angelegt werden: {e} - wird ignoriert')
+                        zones[d] = provider.create_zone(d)
+                        click.echo(f'{d} wurde neu bei {pname} angelegt')
+                    except ProviderError as e:
+                        click.echo(f'{d} konnte bei {pname} nicht angelegt werden: {e} - wird ignoriert')
                         del self.config['domains'][d]
                 else:
-                    click.echo(f'{d} ist konfiguriert aber nicht bei Hetzner eingerichtet - wird ignoriert')
+                    click.echo(f'{d} ist konfiguriert aber nicht bei {pname} eingerichtet - wird ignoriert')
                     del self.config['domains'][d]
-            for d in (hetzner_zones.keys() - config_domains):
-                click.echo(f'{d} ist bei Hetzner eingerichtet aber nicht konfiguriert - bitte prüfen')
-            for d in self.config['domains'].keys():
-                self.config['domains'][d]['zone-id'] = hetzner_zones[d].id
+            for d in (zones.keys() - configured):
+                click.echo(f'{d} ist bei {pname} eingerichtet aber nicht konfiguriert - bitte prüfen')
+            for d in sorted(configured):
+                if d not in self.config['domains']:
+                    continue  # oben verworfen
+                zone = zones[d]
+                self.config['domains'][d]['zone-id'] = zone.id
                 self.config['domains'][d]['zone-file'] = d + '.zone'
-                self._hetzner_zones[d] = hetzner_zones[d]
-        except (hcloud.HCloudException, OSError) as e:
-            click.echo(f'Zonen bei Hetzner konnten nicht ermittelt werden: {e}')
-            sys.exit(1)
+                self._zones[d] = zone
+                self._provider_for[d] = provider
 
     def __init__(self, upload: bool = False, backup: bool = False,
                  write_zone: bool = False, datadir: str = "",
@@ -112,13 +168,16 @@ class DNSJinja:
         self.zone_backups_dir = DNSJinja._check_path(self.config['global']['zone-backups'], self.datadir, 'Zone-Backup-Verzeichnis', expect='dir')
 
         self.auth_api_token = auth_api_token
-        if not self.auth_api_token:
-            click.echo('Kein API-Token angegeben. Bitte --auth-api-token oder DNSJINJA_AUTH_API_TOKEN setzen.')
-            sys.exit(1)
-        self._api_base = self.config['global'].get('dns-api-base', self.DEFAULT_API_BASE).rstrip('/')
-        self.client = Client(token=self.auth_api_token, api_endpoint=self._api_base)
-        self._hetzner_zones: dict[str, Any] = {}
         self._create_missing: bool = create_missing
+
+        # Provider-Pool aufbauen und jede Domain ihrem Provider-Namen zuordnen.
+        default_provider = self._build_provider_pool()
+        self._provider_name_for: dict[str, str] = {
+            d: (dcfg.get('provider') or default_provider)
+            for d, dcfg in self.config['domains'].items()
+        }
+        self._zones: dict[str, Zone] = {}
+        self._provider_for: dict[str, DnsProvider] = {}
 
         self._prepare_zones()
 
@@ -199,11 +258,10 @@ class DNSJinja:
     def _parse_zone_rrsets(self, domain: str) -> dict[tuple[str, str], tuple[int, list[str]]]:
         """Parse gerenderten Zonentext in {(name, rdtype): (ttl, [rdata_values])}.
 
-        SOA-Records werden ausgeschlossen (von Hetzner verwaltet).
-        Owner-Namen werden relativ ausgegeben (inkl. '@' für den Apex, wie
-        Hetzner sie erwartet). RDATA-Ziele werden als FQDN ausgegeben, damit
-        ein CNAME-Ziel auf den Zonen-Apex nicht zu '@' kollabiert (Hetzner
-        lehnt '@' als CNAME-Wert mit invalid_input ab).
+        SOA-Records werden ausgeschlossen (vom Provider verwaltet).
+        Owner-Namen werden relativ ausgegeben (inkl. '@' für den Apex). RDATA-
+        Ziele werden als FQDN ausgegeben, damit ein CNAME-Ziel auf den Zonen-
+        Apex nicht zu '@' kollabiert (siehe Bug #8).
         """
         origin = dns.name.from_text(domain)
         parsed = dns.zone.from_text(self.zones[domain], origin=origin)
@@ -212,7 +270,7 @@ class DNSJinja:
             rel_name = '@' if name == dns.name.empty else str(name)
             for rdataset in node.rdatasets:
                 rdtype = dns.rdatatype.to_text(rdataset.rdtype)
-                if rdtype == 'SOA':
+                if rdtype in self.SYNC_EXCLUDE_TYPES:
                     continue
                 ttl = int(rdataset.ttl)
                 records = sorted(
@@ -222,55 +280,52 @@ class DNSJinja:
         return result
 
     def _sync_zone_rrsets(self, domain: str) -> None:
-        """Synchronisiert gerenderte Zone-RRSets mit Hetzner über die Record-Level-API."""
-        zone = self._hetzner_zones[domain]
+        """Synchronisiert gerenderte Zone-RRSets über die Record-Level-API des
+        zuständigen Providers."""
+        provider = self._provider_for[domain]
+        zone = self._zones[domain]
         desired = self._parse_zone_rrsets(domain)
 
-        current_rrsets = self.client.zones.get_rrset_all(zone)
         current_map: dict[tuple[str, str], Any] = {}
-        for rrset in current_rrsets:
-            if rrset.type == 'SOA':
+        for rrset in provider.get_rrsets(zone):
+            if rrset.type in self.SYNC_EXCLUDE_TYPES:
                 continue
             current_map[(rrset.name, rrset.type)] = rrset
 
         # Create / Update
         for (name, rdtype), (ttl, records) in desired.items():
-            hetzner_records = [ZoneRecord(value=v) for v in records]
             key = (name, rdtype)
-
             if key in current_map:
                 existing = current_map[key]
-                if existing.protection and existing.protection.get('change'):
+                if existing.protected:
                     logger.warning('RRSet %s/%s ist geschützt, wird übersprungen', name, rdtype)
                     continue
-                existing_values = sorted(r.value for r in (existing.records or []))
-                if existing_values != records or existing.ttl != ttl:
-                    self.client.zones.set_rrset_records(existing, hetzner_records)
+                if sorted(existing.records) != records or existing.ttl != ttl:
+                    provider.set_rrset_records(zone, existing, records)
                     if existing.ttl != ttl:
-                        self.client.zones.change_rrset_ttl(existing, ttl)
+                        provider.set_rrset_ttl(zone, existing, ttl)
             else:
-                self.client.zones.create_rrset(
-                    zone, name=name, type=rdtype, ttl=ttl, records=hetzner_records,
-                )
+                provider.create_rrset(zone, name, rdtype, ttl, records)
 
         # Delete stale RRSets
         for (name, rdtype), rrset in current_map.items():
             if (name, rdtype) in desired:
                 continue
-            if rrset.protection and rrset.protection.get('change'):
+            if rrset.protected:
                 logger.warning('RRSet %s/%s ist geschützt, Löschung übersprungen', name, rdtype)
                 continue
             try:
-                self.client.zones.delete_rrset(rrset)
-            except hcloud.APIException as e:
+                provider.delete_rrset(zone, rrset)
+            except ProviderError as e:
                 logger.warning('RRSet %s/%s konnte nicht gelöscht werden: %s', name, rdtype, e)
 
     def upload_zone(self, domain: str) -> None:
         self._validate_zone_syntax(domain)
+        provider = self._provider_for[domain]
         try:
             self._sync_zone_rrsets(domain)
-            click.echo(f'Domäne {domain} wurde bei Hetzner erfolgreich aktualisiert')
-        except hcloud.APIException as e:
+            click.echo(f'Domäne {domain} wurde bei {provider.name} erfolgreich aktualisiert')
+        except ProviderError as e:
             self.exit_status_file.write_text("254", encoding='utf-8')
             raise UploadError(f'\nDomain: {domain}\nError Message: {e}')
 
@@ -281,17 +336,22 @@ class DNSJinja:
             try:
                 self.upload_zone(domain)
             except UploadError as e:
-                click.echo(f'Domäne {domain} konnte bei Hetzner nicht aktualisiert werden: {str(e)}')
+                click.echo(f'Domäne {domain} konnte nicht aktualisiert werden: {str(e)}')
                 continue
 
     def backup_zone(self, domain: str) -> None:
+        provider = self._provider_for[domain]
+        zone = self._zones[domain]
+        if not provider.supports_zonefile_export():
+            click.echo(f'Domäne {domain}: Provider {provider.name} unterstützt keinen '
+                       f'Zonefile-Export – Backup übersprungen')
+            return
         try:
-            zone = self._hetzner_zones[domain]
-            response = self.client.zones.export_zonefile(zone)
+            content = provider.export_zonefile(zone)
             backupfile = self.zone_backups_dir / Path(self.config['domains'][domain]['zone-file'] + f'.{self._get_zone_serial(domain)}')
-            backupfile.write_text(response.zonefile + '\n', encoding='utf-8')
+            backupfile.write_text(content + '\n', encoding='utf-8')
             click.echo(f'Domäne {domain} wurde erfolgreich gesichert')
-        except (hcloud.APIException, OSError) as e:
+        except (ProviderError, OSError) as e:
             click.echo(f'Domäne {domain} konnte nicht gesichert werden: {str(e)}')
 
     def backup_zones(self) -> None:
@@ -313,11 +373,11 @@ class DNSJinja:
 @click.option('-u', '--upload', is_flag=True, default=False, help="Upload der Zonen")
 @click.option('-b', '--backup', is_flag=True, default=False, help="Backup der Zonen")
 @click.option('-w', '--write', is_flag=True, default=False, help="Zone-Files schreiben")
-@click.option('-C', '--create-missing', is_flag=True, default=False, help="Konfigurierte Domains, die bei Hetzner nicht existieren, neu anlegen")
-@click.option('--auth-api-token', default="", envvar='DNSJINJA_AUTH_API_TOKEN', help="API-Token (Bearer) für Hetzner Cloud API (DNSJINJA_AUTH_API_TOKEN)")
+@click.option('-C', '--create-missing', is_flag=True, default=False, help="Konfigurierte Domains, die beim Provider nicht existieren, neu anlegen")
+@click.option('--auth-api-token', default="", envvar='DNSJINJA_AUTH_API_TOKEN', help="API-Token (Bearer) für die DNS-Provider-API (DNSJINJA_AUTH_API_TOKEN)")
 @click.option('--dry-run', 'dry_run', is_flag=True, default=False, help="Zone-Files rendern und ausgeben, ohne zu schreiben oder hochzuladen")
 def run(upload, backup, write, datadir, config, auth_api_token, create_missing, dry_run):
-    """Modulare Verwaltung von DNS-Zonen (Hetzner Cloud API)"""
+    """Modulare Verwaltung von DNS-Zonen über austauschbare Provider-Plugins"""
     if dry_run:
         dnsjinja = DNSJinja(False, False, False, datadir, config, auth_api_token, create_missing)
         dnsjinja.dry_run()

--- a/src/dnsjinja/dnsjinja_config_schema.py
+++ b/src/dnsjinja/dnsjinja_config_schema.py
@@ -1,10 +1,20 @@
-from pydantic import BaseModel, Field, ConfigDict
+from pydantic import BaseModel, Field, ConfigDict, model_validator
 
 
 class DomainConfig(BaseModel):
     """Konfiguration für eine einzelne Domain (Validierungs-Modell)."""
     model_config = ConfigDict(extra='allow', populate_by_name=True)
     template: str
+    # Optionaler Verweis auf einen Provider aus global.providers (Multiprovider, #10).
+    provider: str | None = None
+
+
+class ProviderDef(BaseModel):
+    """Definition eines benannten DNS-Providers (Multiprovider, #10)."""
+    model_config = ConfigDict(extra='allow', populate_by_name=True)
+    plugin: str
+    api_base: str | None = Field(default=None, alias='api-base')
+    token_env: str | None = Field(default=None, alias='token-env')
 
 
 class GlobalConfig(BaseModel):
@@ -14,11 +24,17 @@ class GlobalConfig(BaseModel):
     zone_backups: str = Field(alias='zone-backups')
     templates: str
     name_servers: list[str] = Field(alias='name-servers')
+    # Legacy-Single-Provider-Feld: API-Endpoint (provider-spezifischer Default).
     dns_api_base: str = Field(
         default='https://api.hetzner.cloud/v1',
         alias='dns-api-base',
         pattern=r'^https://',
     )
+    # Legacy: Plugin-Kennung für den impliziten Single-Provider (Default hetzner).
+    provider: str | None = None
+    # Multiprovider (#10): benannte Provider-Definitionen + Default.
+    providers: dict[str, ProviderDef] | None = None
+    default_provider: str | None = Field(default=None, alias='default-provider')
 
 
 class DnsJinjaConfig(BaseModel):
@@ -26,3 +42,34 @@ class DnsJinjaConfig(BaseModel):
     model_config = ConfigDict(extra='allow', populate_by_name=True)
     global_config: GlobalConfig = Field(alias='global')
     domains: dict[str, DomainConfig]
+
+    @model_validator(mode='after')
+    def _check_provider_references(self) -> 'DnsJinjaConfig':
+        providers = self.global_config.providers
+        provider_names = set(providers) if providers else set()
+
+        default_provider = self.global_config.default_provider
+        if default_provider and default_provider not in provider_names:
+            raise ValueError(
+                f"default-provider {default_provider!r} ist nicht in global.providers definiert")
+
+        for domain, dcfg in self.domains.items():
+            if dcfg.provider is None:
+                continue
+            if not providers:
+                raise ValueError(
+                    f"Domain {domain!r} verweist auf Provider {dcfg.provider!r}, "
+                    f"aber global.providers ist nicht definiert")
+            if dcfg.provider not in provider_names:
+                raise ValueError(
+                    f"Domain {domain!r} verweist auf unbekannten Provider {dcfg.provider!r}. "
+                    f"Verfügbar: {', '.join(sorted(provider_names))}")
+
+        if providers and not default_provider and len(providers) > 1:
+            # Domains ohne expliziten Provider brauchen einen Default.
+            domains_without = [d for d, c in self.domains.items() if c.provider is None]
+            if domains_without:
+                raise ValueError(
+                    "Mehrere Provider konfiguriert, aber kein default-provider; "
+                    f"Domains ohne provider-Feld: {', '.join(sorted(domains_without))}")
+        return self

--- a/src/dnsjinja/providers/__init__.py
+++ b/src/dnsjinja/providers/__init__.py
@@ -1,0 +1,25 @@
+"""DNS-Provider-Abstraktion und Plugin-System (Tickets #9/#10)."""
+from .base import (
+    DnsProvider,
+    ProviderAuthError,
+    ProviderError,
+    ProviderNotFoundError,
+    ProviderTransientError,
+    RRSet,
+    Zone,
+)
+from .pool import ProviderPool
+from .registry import available_plugins, load_provider
+
+__all__ = [
+    "DnsProvider",
+    "Zone",
+    "RRSet",
+    "ProviderError",
+    "ProviderAuthError",
+    "ProviderNotFoundError",
+    "ProviderTransientError",
+    "ProviderPool",
+    "load_provider",
+    "available_plugins",
+]

--- a/src/dnsjinja/providers/base.py
+++ b/src/dnsjinja/providers/base.py
@@ -1,0 +1,136 @@
+"""Provider-neutrale Schnittstelle für DNS-Provider (Ticket #9).
+
+`DNSJinja` programmiert ausschließlich gegen die hier definierten Typen und
+die abstrakte Basis `DnsProvider`. Konkrete Provider (Hetzner, deSEC, …)
+liegen als Plugins in eigenen Modulen und werden über die Registry geladen.
+"""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any
+
+
+# ---------------------------------------------------------------------------
+# Provider-neutrale Datentypen
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Zone:
+    """Eine DNS-Zone bei einem Provider.
+
+    `handle` kapselt das provider-eigene Objekt opak; der Kern reicht es nur
+    durch und interpretiert es nicht.
+    """
+    name: str
+    id: Any
+    handle: Any = None
+
+
+@dataclass
+class RRSet:
+    """Ein Resource-Record-Set provider-neutral.
+
+    `name` ist der relative Owner-Name inkl. ``@`` für den Zonen-Apex.
+    `records` sind die RDATA-Werte in Presentation-Form (FQDN mit Punkt).
+    `handle` kapselt das provider-eigene RRSet-Objekt für spätere
+    Update-/Delete-Operationen.
+    """
+    name: str
+    type: str
+    ttl: int
+    records: list[str] = field(default_factory=list)
+    protected: bool = False
+    handle: Any = None
+
+
+# ---------------------------------------------------------------------------
+# Provider-neutrale Fehlerhierarchie
+# ---------------------------------------------------------------------------
+
+class ProviderError(Exception):
+    """Basisfehler für alle Provider-Operationen.
+
+    Konkrete Plugins mappen ihre nativen Fehler (z. B. ``hcloud.APIException``)
+    auf diese Hierarchie; der Kern fängt ausschließlich ``ProviderError``.
+    """
+
+
+class ProviderAuthError(ProviderError):
+    """Authentifizierung/Autorisierung fehlgeschlagen (401/403, fehlendes Token)."""
+
+
+class ProviderNotFoundError(ProviderError):
+    """Angeforderte Ressource existiert nicht (404)."""
+
+
+class ProviderTransientError(ProviderError):
+    """Vorübergehender Fehler (Netz, 5xx, Rate-Limit) – ein Retry kann helfen."""
+
+
+# ---------------------------------------------------------------------------
+# Abstrakte Provider-Schnittstelle
+# ---------------------------------------------------------------------------
+
+class DnsProvider(ABC):
+    """Provider-neutrale DNS-Operationen.
+
+    Die gesamte Diff-/Sync-Logik (Vergleich Soll/Ist, create/update/delete,
+    Protection-Behandlung) liegt im Kern (`DNSJinja`). Ein Plugin liefert nur
+    die unten stehenden Primitive.
+    """
+
+    #: Kurzkennung des Plugins (z. B. "hetzner"), von der Registry gesetzt.
+    name: str = "base"
+
+    #: Ob der Provider DNSSEC-Signierung unterstützt (Ticket #11).
+    supports_dnssec: bool = False
+
+    # -- Zonen -------------------------------------------------------------
+
+    @abstractmethod
+    def list_zones(self) -> dict[str, Zone]:
+        """Alle beim Provider vorhandenen Zonen als ``{name: Zone}``."""
+
+    @abstractmethod
+    def create_zone(self, name: str) -> Zone:
+        """Eine neue Zone anlegen und zurückgeben."""
+
+    # -- RRSets ------------------------------------------------------------
+
+    @abstractmethod
+    def get_rrsets(self, zone: Zone) -> list[RRSet]:
+        """Alle RRSets einer Zone (SOA/Signatur-Records darf der Provider
+        weglassen; der Kern filtert zusätzlich)."""
+
+    @abstractmethod
+    def create_rrset(self, zone: Zone, name: str, type: str, ttl: int,
+                     records: list[str]) -> None:
+        """Ein neues RRSet anlegen."""
+
+    @abstractmethod
+    def set_rrset_records(self, zone: Zone, rrset: RRSet,
+                          records: list[str]) -> None:
+        """Die RDATA-Werte eines bestehenden RRSets ersetzen."""
+
+    @abstractmethod
+    def set_rrset_ttl(self, zone: Zone, rrset: RRSet, ttl: int) -> None:
+        """Den TTL eines bestehenden RRSets ändern."""
+
+    @abstractmethod
+    def delete_rrset(self, zone: Zone, rrset: RRSet) -> None:
+        """Ein RRSet löschen."""
+
+    # -- Optionales --------------------------------------------------------
+
+    def supports_zonefile_export(self) -> bool:
+        """Ob ``export_zonefile`` unterstützt wird (für Backups)."""
+        return True
+
+    def export_zonefile(self, zone: Zone) -> str:
+        """Die Zone als BIND-Zonefile-Text exportieren."""
+        raise NotImplementedError(
+            f"Provider {self.name!r} unterstützt keinen Zonefile-Export")
+
+    def close(self) -> None:
+        """Optionale Ressourcenfreigabe."""

--- a/src/dnsjinja/providers/hetzner.py
+++ b/src/dnsjinja/providers/hetzner.py
@@ -1,0 +1,131 @@
+"""Hetzner-Cloud-DNS-Provider-Plugin (Ticket #9).
+
+Kapselt die `hcloud`-SDK hinter der provider-neutralen `DnsProvider`-
+Schnittstelle. `hcloud` wird nur importiert, wenn dieses Plugin geladen wird –
+der Kern (`dnsjinja.dnsjinja`) bleibt frei von Hetzner-Abhängigkeiten.
+"""
+from __future__ import annotations
+
+import hcloud
+from hcloud import Client
+from hcloud.zones.domain import ZoneRecord
+
+from .base import (
+    DnsProvider,
+    ProviderAuthError,
+    ProviderError,
+    ProviderNotFoundError,
+    ProviderTransientError,
+    RRSet,
+    Zone,
+)
+
+
+def _translate(exc: Exception) -> ProviderError:
+    """Native hcloud-/OS-Fehler auf die ProviderError-Hierarchie abbilden."""
+    if isinstance(exc, hcloud.APIException):
+        code = exc.code
+        if code in (401, 403, "unauthorized", "forbidden"):
+            return ProviderAuthError(str(exc))
+        if code in (404, "not_found"):
+            return ProviderNotFoundError(str(exc))
+        return ProviderError(str(exc))
+    if isinstance(exc, (hcloud.HCloudException, OSError)):
+        return ProviderTransientError(str(exc))
+    return ProviderError(str(exc))
+
+
+class HetznerProvider(DnsProvider):
+
+    name = "hetzner"
+    supports_dnssec = False
+
+    DEFAULT_API_BASE = "https://api.hetzner.cloud/v1"
+
+    def __init__(self, *, token: str, api_base: str | None = None,
+                 options: dict | None = None) -> None:
+        if not token:
+            raise ProviderAuthError("Kein API-Token für den Hetzner-Provider angegeben.")
+        base = (api_base or self.DEFAULT_API_BASE).rstrip("/")
+        self._client = Client(token=token, api_endpoint=base)
+
+    # -- Zonen -------------------------------------------------------------
+
+    def list_zones(self) -> dict[str, Zone]:
+        try:
+            return {
+                z.name: Zone(name=z.name, id=z.id, handle=z)
+                for z in self._client.zones.get_all()
+            }
+        except (hcloud.HCloudException, OSError) as e:
+            raise _translate(e) from e
+
+    def create_zone(self, name: str) -> Zone:
+        try:
+            response = self._client.zones.create(name=name, mode="primary")
+        except (hcloud.HCloudException, OSError) as e:
+            raise _translate(e) from e
+        z = response.zone
+        return Zone(name=z.name, id=z.id, handle=z)
+
+    # -- RRSets ------------------------------------------------------------
+
+    def get_rrsets(self, zone: Zone) -> list[RRSet]:
+        try:
+            rrsets = self._client.zones.get_rrset_all(zone.handle)
+        except (hcloud.HCloudException, OSError) as e:
+            raise _translate(e) from e
+        result: list[RRSet] = []
+        for rr in rrsets:
+            protected = bool(rr.protection and rr.protection.get("change"))
+            result.append(RRSet(
+                name=rr.name,
+                type=rr.type,
+                ttl=rr.ttl,
+                records=sorted(r.value for r in (rr.records or [])),
+                protected=protected,
+                handle=rr,
+            ))
+        return result
+
+    def create_rrset(self, zone: Zone, name: str, type: str, ttl: int,
+                     records: list[str]) -> None:
+        try:
+            self._client.zones.create_rrset(
+                zone.handle, name=name, type=type, ttl=ttl,
+                records=[ZoneRecord(value=v) for v in records],
+            )
+        except (hcloud.HCloudException, OSError) as e:
+            raise _translate(e) from e
+
+    def set_rrset_records(self, zone: Zone, rrset: RRSet,
+                          records: list[str]) -> None:
+        try:
+            self._client.zones.set_rrset_records(
+                rrset.handle, [ZoneRecord(value=v) for v in records],
+            )
+        except (hcloud.HCloudException, OSError) as e:
+            raise _translate(e) from e
+
+    def set_rrset_ttl(self, zone: Zone, rrset: RRSet, ttl: int) -> None:
+        try:
+            self._client.zones.change_rrset_ttl(rrset.handle, ttl)
+        except (hcloud.HCloudException, OSError) as e:
+            raise _translate(e) from e
+
+    def delete_rrset(self, zone: Zone, rrset: RRSet) -> None:
+        try:
+            self._client.zones.delete_rrset(rrset.handle)
+        except (hcloud.HCloudException, OSError) as e:
+            raise _translate(e) from e
+
+    # -- Backup ------------------------------------------------------------
+
+    def supports_zonefile_export(self) -> bool:
+        return True
+
+    def export_zonefile(self, zone: Zone) -> str:
+        try:
+            return self._client.zones.export_zonefile(zone.handle).zonefile
+        except (hcloud.HCloudException, OSError) as e:
+            raise _translate(e) from e

--- a/src/dnsjinja/providers/pool.py
+++ b/src/dnsjinja/providers/pool.py
@@ -1,0 +1,77 @@
+"""Provider-Pool für den Multiprovider-Betrieb (Ticket #10).
+
+Hält pro **benannter** Provider-Konfiguration genau eine `DnsProvider`-
+Instanz (lazy erzeugt und gecacht). Schlüssel ist der Konfig-Name, nicht der
+Plugin-Typ – so sind z. B. zwei Hetzner-Accounts mit unterschiedlichen Tokens
+nebeneinander möglich.
+"""
+from __future__ import annotations
+
+import os
+from typing import Callable
+
+from . import registry
+from .base import DnsProvider, ProviderAuthError, ProviderError
+
+
+class ProviderPool:
+    """Verwaltet benannte Provider-Definitionen und ihre Instanzen.
+
+    `definitions` bildet einen Namen auf eine Definition ab::
+
+        {"hetzner-main": {"plugin": "hetzner",
+                          "api-base": "https://api.hetzner.cloud/v1",
+                          "token-env": "DNSJINJA_TOKEN_HETZNER_MAIN"}}
+
+    Fehlt ``token-env``, wird `default_token` (z. B. ``--auth-api-token``)
+    verwendet – das deckt den Single-Provider-/Legacy-Fall ab.
+    """
+
+    def __init__(self, definitions: dict[str, dict], *, default_token: str = "",
+                 loader: Callable[..., DnsProvider] | None = None) -> None:
+        self._definitions = definitions
+        self._default_token = default_token
+        self._loader = loader
+        self._instances: dict[str, DnsProvider] = {}
+
+    @property
+    def names(self) -> list[str]:
+        return list(self._definitions.keys())
+
+    def _resolve_token(self, name: str, defn: dict) -> str:
+        token_env = defn.get("token-env") or defn.get("token_env")
+        if token_env:
+            token = os.environ.get(token_env, "")
+            if not token:
+                raise ProviderAuthError(
+                    f"Provider {name!r}: Umgebungsvariable {token_env} ist nicht gesetzt.")
+            return token
+        if not self._default_token:
+            raise ProviderAuthError(
+                f"Provider {name!r}: kein API-Token (weder token-env noch --auth-api-token).")
+        return self._default_token
+
+    def get(self, name: str) -> DnsProvider:
+        """Provider-Instanz für einen Konfig-Namen (lazy, gecacht)."""
+        if name in self._instances:
+            return self._instances[name]
+        if name not in self._definitions:
+            raise ProviderError(
+                f"Unbekannter Provider {name!r}. "
+                f"Konfiguriert: {', '.join(self._definitions) or '(keine)'}")
+        defn = self._definitions[name]
+        plugin = defn.get("plugin", "hetzner")
+        api_base = defn.get("api-base") or defn.get("api_base")
+        token = self._resolve_token(name, defn)
+        load = self._loader or registry.load_provider
+        provider = load(plugin, token=token, api_base=api_base, options=defn)
+        self._instances[name] = provider
+        return provider
+
+    def close(self) -> None:
+        for provider in self._instances.values():
+            try:
+                provider.close()
+            except Exception:
+                pass
+        self._instances.clear()

--- a/src/dnsjinja/providers/registry.py
+++ b/src/dnsjinja/providers/registry.py
@@ -1,0 +1,70 @@
+"""Plugin-Discovery für DNS-Provider (Ticket #9).
+
+Auflösung einer Plugin-Kennung auf eine `DnsProvider`-Klasse, in dieser
+Reihenfolge:
+
+1. Expliziter Import-Pfad ``"paket.modul:Klasse"`` (Override/Fallback).
+2. Entry-Point der Gruppe ``dnsjinja.providers`` (externe Plugin-Pakete).
+3. Eingebaute Plugins (`_BUILTIN`) – damit der mitgelieferte Hetzner-Provider
+   auch ohne (Neu-)Installation der Entry-Points funktioniert.
+"""
+from __future__ import annotations
+
+import importlib
+from importlib import metadata
+
+from .base import DnsProvider, ProviderError
+
+ENTRY_POINT_GROUP = "dnsjinja.providers"
+
+#: Mitgelieferte Plugins als Fallback zu den Entry-Points.
+_BUILTIN: dict[str, str] = {
+    "hetzner": "dnsjinja.providers.hetzner:HetznerProvider",
+}
+
+
+def _load_path(path: str) -> type[DnsProvider]:
+    module_name, _, attr = path.partition(":")
+    module = importlib.import_module(module_name)
+    return getattr(module, attr)
+
+
+def _entry_points() -> dict[str, metadata.EntryPoint]:
+    try:
+        eps = metadata.entry_points(group=ENTRY_POINT_GROUP)
+    except Exception:
+        return {}
+    return {ep.name: ep for ep in eps}
+
+
+def available_plugins() -> list[str]:
+    """Namen aller auflösbaren Plugins (Builtins + Entry-Points)."""
+    return sorted(set(_BUILTIN) | set(_entry_points()))
+
+
+def _resolve_class(plugin: str) -> type[DnsProvider]:
+    if ":" in plugin:
+        return _load_path(plugin)
+
+    eps = _entry_points()
+    if plugin in eps:
+        return eps[plugin].load()
+
+    if plugin in _BUILTIN:
+        return _load_path(_BUILTIN[plugin])
+
+    raise ProviderError(
+        f"Unbekanntes Provider-Plugin {plugin!r}. "
+        f"Verfügbar: {', '.join(available_plugins()) or '(keine)'}"
+    )
+
+
+def load_provider(plugin: str, *, token: str, api_base: str | None = None,
+                  options: dict | None = None) -> DnsProvider:
+    """Plugin laden und eine Provider-Instanz erzeugen."""
+    cls = _resolve_class(plugin)
+    provider = cls(token=token, api_base=api_base, options=options or {})
+    # Kennung am Objekt sicherstellen (Plugins setzen i. d. R. `name`).
+    if not getattr(provider, "name", None) or provider.name == "base":
+        provider.name = plugin
+    return provider

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -116,34 +116,122 @@ def config_file(data_dir):
 
 
 # ---------------------------------------------------------------------------
-# Mock-Fixtures für Unit-Tests
+# FakeProvider – provider-neutraler In-Memory-Ersatz (Tickets #9/#10)
 # ---------------------------------------------------------------------------
 
-@pytest.fixture
-def mock_zone():
-    """Gemocktes BoundZone-Objekt für example.com."""
-    from unittest.mock import MagicMock
-    zone = MagicMock()
-    zone.name = 'example.com'
-    zone.id = 'test-zone-id-123'
-    return zone
+from dnsjinja.providers.base import DnsProvider, ProviderError, RRSet, Zone
+
+
+class FakeProvider(DnsProvider):
+    """In-Memory-`DnsProvider` für Offline-Tests ohne hcloud.
+
+    Zeichnet alle mutierenden Aufrufe in `self.calls` auf und erlaubt das
+    gezielte Auslösen von `ProviderError` pro Methode (`fail`) oder pro Zone
+    (`fail_zones`).
+    """
+
+    name = "fake"
+
+    def __init__(self, *, token=None, api_base=None, options=None,
+                 zones=None, rrsets=None, export_text=None,
+                 supports_export=True, fail=None, fail_zones=None):
+        self.token = token
+        self.api_base = api_base
+        self.options = options or {}
+        self._zones = {n: Zone(name=n, id=f'id-{n}', handle=object()) for n in (zones or [])}
+        self._rrsets = {k: list(v) for k, v in (rrsets or {}).items()}
+        self._export_text = export_text if export_text is not None else '$ORIGIN example.com.\n$TTL 3600\n'
+        self._supports_export = supports_export
+        self.fail = dict(fail or {})
+        self.fail_zones = set(fail_zones or [])
+        self.calls = []
+
+    def _maybe_fail(self, method, zone_name=None):
+        if method in self.fail:
+            raise self.fail[method]
+        if zone_name is not None and zone_name in self.fail_zones:
+            raise ProviderError(f"Fake-Fehler für Zone {zone_name}")
+
+    def list_zones(self):
+        self._maybe_fail('list_zones')
+        self.calls.append(('list_zones',))
+        return dict(self._zones)
+
+    def create_zone(self, name):
+        self._maybe_fail('create_zone')
+        z = Zone(name=name, id=f'id-{name}', handle=object())
+        self._zones[name] = z
+        self.calls.append(('create_zone', name))
+        return z
+
+    def get_rrsets(self, zone):
+        self._maybe_fail('get_rrsets', zone.name)
+        self.calls.append(('get_rrsets', zone.name))
+        return list(self._rrsets.get(zone.name, []))
+
+    def create_rrset(self, zone, name, type, ttl, records):
+        self._maybe_fail('create_rrset')
+        self.calls.append(('create_rrset', zone.name, name, type, ttl, list(records)))
+
+    def set_rrset_records(self, zone, rrset, records):
+        self._maybe_fail('set_rrset_records')
+        self.calls.append(('set_rrset_records', zone.name, rrset.name, rrset.type, list(records)))
+
+    def set_rrset_ttl(self, zone, rrset, ttl):
+        self._maybe_fail('set_rrset_ttl')
+        self.calls.append(('set_rrset_ttl', zone.name, rrset.name, rrset.type, ttl))
+
+    def delete_rrset(self, zone, rrset):
+        self._maybe_fail('delete_rrset')
+        self.calls.append(('delete_rrset', zone.name, rrset.name, rrset.type))
+
+    def supports_zonefile_export(self):
+        return self._supports_export
+
+    def export_zonefile(self, zone):
+        self._maybe_fail('export_zonefile', zone.name)
+        self.calls.append(('export_zonefile', zone.name))
+        return self._export_text
+
+    # -- Test-Hilfen -------------------------------------------------------
+
+    def calls_of(self, method):
+        return [c for c in self.calls if c[0] == method]
+
+
+def install_provider_loader(monkeypatch, provider_or_factory):
+    """Patcht die Registry so, dass `load_provider` den/die Fake liefert.
+
+    `provider_or_factory` ist entweder eine einzelne `DnsProvider`-Instanz
+    (für Single-Provider-Tests) oder eine Funktion ``plugin -> DnsProvider``
+    (für Multiprovider-Tests).
+    """
+    if callable(provider_or_factory) and not isinstance(provider_or_factory, DnsProvider):
+        def _loader(plugin, *, token, api_base=None, options=None):
+            return provider_or_factory(plugin)
+    else:
+        def _loader(plugin, *, token, api_base=None, options=None):
+            return provider_or_factory
+    monkeypatch.setattr('dnsjinja.providers.registry.load_provider', _loader)
 
 
 @pytest.fixture
-def mock_client(mock_zone):
-    """Vollständig gemockter hcloud.Client."""
-    from unittest.mock import MagicMock, patch
+def make_dj(data_dir, mock_dns_resolver, monkeypatch):
+    """Factory: DNSJinja mit injiziertem FakeProvider (oder Provider-Factory)."""
+    from dnsjinja.dnsjinja import DNSJinja
 
-    export_resp = MagicMock()
-    export_resp.zonefile = '$ORIGIN example.com.\n$TTL 3600\n'
+    def _make(config_path, provider=None, **kwargs):
+        if provider is None:
+            provider = FakeProvider(zones=['example.com'])
+        install_provider_loader(monkeypatch, provider)
+        return DNSJinja(
+            datadir=str(data_dir),
+            config_file=str(config_path),
+            auth_api_token='test-token-unit',
+            **kwargs,
+        )
 
-    with patch('dnsjinja.dnsjinja.Client') as mock_class:
-        client = MagicMock()
-        mock_class.return_value = client
-        client.zones.get_all.return_value = [mock_zone]
-        client.zones.export_zonefile.return_value = export_resp
-        client.zones.get_rrset_all.return_value = []
-        yield client
+    return _make
 
 
 @pytest.fixture
@@ -187,37 +275,14 @@ def make_testdata_config(domains_cfg: dict) -> dict:
     }
 
 
-class _FakeZones:
-    """Minimaler Ersatz für client.zones (nur was _prepare_zones braucht)."""
-
-    def __init__(self, names):
-        from unittest.mock import MagicMock
-        self._zones = []
-        for n in names:
-            z = MagicMock()
-            z.name = n
-            z.id = f'id-{n}'
-            self._zones.append(z)
-
-    def get_all(self):
-        return list(self._zones)
-
-    def get_rrset_all(self, zone):
-        return []
-
-
-class _FakeClient:
-    def __init__(self, names):
-        self.zones = _FakeZones(names)
-
-
 @pytest.fixture
 def build_dj(testdata_dir, tmp_path, mock_dns_resolver, monkeypatch):
     """Factory: baut eine DNSJinja-Instanz gegen testdata/-Templates.
 
-    Hetzner-Client und DNS-Resolver sind gemockt; get_all() liefert genau
-    die konfigurierten Domains, damit _prepare_zones sie nicht verwirft.
-    Reines Rendering – es werden keine Zone-Files geschrieben.
+    Der DNS-Provider ist ein In-Memory-`FakeProvider`, dessen `list_zones()`
+    genau die konfigurierten Domains liefert, damit _prepare_zones sie nicht
+    verwirft. Der DNS-Resolver ist gemockt. Reines Rendering – es werden keine
+    Zone-Files geschrieben.
     """
     from dnsjinja.dnsjinja import DNSJinja
 
@@ -229,11 +294,8 @@ def build_dj(testdata_dir, tmp_path, mock_dns_resolver, monkeypatch):
         counter['n'] += 1
         cfg_path.write_text(json.dumps(cfg), encoding='utf-8')
 
-        fake = _FakeClient(list(domains_cfg.keys()))
-        monkeypatch.setattr(
-            'dnsjinja.dnsjinja.Client',
-            lambda token, api_endpoint: fake,
-        )
+        provider = FakeProvider(zones=list(domains_cfg.keys()))
+        install_provider_loader(monkeypatch, provider)
         return DNSJinja(
             datadir=str(testdata_dir),
             config_file=str(cfg_path),

--- a/tests/test_hetzner_provider.py
+++ b/tests/test_hetzner_provider.py
@@ -1,0 +1,154 @@
+"""Tests für das Hetzner-Plugin (Ticket #9).
+
+Die hcloud-SDK ist gemockt; dies ist die einzige Stelle, an der noch ein
+hcloud-Mock benötigt wird (Kern-Tests laufen über den FakeProvider).
+"""
+import hcloud
+import pytest
+from unittest.mock import MagicMock, patch
+
+from dnsjinja.providers.base import (
+    ProviderAuthError,
+    ProviderError,
+    ProviderNotFoundError,
+    RRSet,
+    Zone,
+)
+from dnsjinja.providers.hetzner import HetznerProvider
+
+
+@pytest.fixture
+def mock_client():
+    with patch('dnsjinja.providers.hetzner.Client') as mock_class:
+        client = MagicMock()
+        mock_class.return_value = client
+        yield client
+
+
+@pytest.fixture
+def provider(mock_client):
+    return HetznerProvider(token='test-token')
+
+
+def test_kein_token_wirft_auth_error():
+    with pytest.raises(ProviderAuthError):
+        HetznerProvider(token='')
+
+
+def test_list_zones(provider, mock_client):
+    z = MagicMock(); z.name = 'example.com'; z.id = 'zid-1'
+    mock_client.zones.get_all.return_value = [z]
+
+    zones = provider.list_zones()
+
+    assert set(zones) == {'example.com'}
+    assert zones['example.com'].id == 'zid-1'
+    assert zones['example.com'].handle is z
+
+
+def test_create_zone_nutzt_mode_primary(provider, mock_client):
+    new_zone = MagicMock(); new_zone.name = 'neu.de'; new_zone.id = 'zid-neu'
+    resp = MagicMock(); resp.zone = new_zone
+    mock_client.zones.create.return_value = resp
+
+    zone = provider.create_zone('neu.de')
+
+    mock_client.zones.create.assert_called_once_with(name='neu.de', mode='primary')
+    assert zone.id == 'zid-neu'
+
+
+def test_get_rrsets_mapping_und_protection(provider, mock_client):
+    rec1 = MagicMock(); rec1.value = '192.0.2.2'
+    rec2 = MagicMock(); rec2.value = '192.0.2.1'
+    rr = MagicMock()
+    rr.name = '@'; rr.type = 'A'; rr.ttl = 300
+    rr.records = [rec1, rec2]
+    rr.protection = {'change': True}
+    mock_client.zones.get_rrset_all.return_value = [rr]
+
+    zone = Zone(name='example.com', id='zid', handle=object())
+    result = provider.get_rrsets(zone)
+
+    assert len(result) == 1
+    got = result[0]
+    assert got.name == '@' and got.type == 'A' and got.ttl == 300
+    assert got.records == ['192.0.2.1', '192.0.2.2']  # sortiert
+    assert got.protected is True
+    assert got.handle is rr
+
+
+def test_create_rrset_uebergibt_zonerecords(provider, mock_client):
+    zone = Zone(name='example.com', id='zid', handle='zone-handle')
+
+    provider.create_rrset(zone, '@', 'NS', 300, ['a.ns.example.', 'b.ns.example.'])
+
+    args, kwargs = mock_client.zones.create_rrset.call_args
+    assert args[0] == 'zone-handle'
+    assert kwargs['name'] == '@' and kwargs['type'] == 'NS' and kwargs['ttl'] == 300
+    assert [r.value for r in kwargs['records']] == ['a.ns.example.', 'b.ns.example.']
+
+
+def test_set_rrset_records(provider, mock_client):
+    zone = Zone(name='example.com', id='zid', handle=object())
+    rrset = RRSet(name='@', type='A', ttl=300, records=[], handle='rr-handle')
+
+    provider.set_rrset_records(zone, rrset, ['203.0.113.1'])
+
+    args, _ = mock_client.zones.set_rrset_records.call_args
+    assert args[0] == 'rr-handle'
+    assert [r.value for r in args[1]] == ['203.0.113.1']
+
+
+def test_set_rrset_ttl(provider, mock_client):
+    zone = Zone(name='example.com', id='zid', handle=object())
+    rrset = RRSet(name='@', type='A', ttl=300, records=[], handle='rr-handle')
+
+    provider.set_rrset_ttl(zone, rrset, 600)
+
+    mock_client.zones.change_rrset_ttl.assert_called_once_with('rr-handle', 600)
+
+
+def test_delete_rrset(provider, mock_client):
+    zone = Zone(name='example.com', id='zid', handle=object())
+    rrset = RRSet(name='old', type='A', ttl=300, records=[], handle='rr-handle')
+
+    provider.delete_rrset(zone, rrset)
+
+    mock_client.zones.delete_rrset.assert_called_once_with('rr-handle')
+
+
+def test_export_zonefile(provider, mock_client):
+    resp = MagicMock(); resp.zonefile = '$ORIGIN example.com.\n'
+    mock_client.zones.export_zonefile.return_value = resp
+    zone = Zone(name='example.com', id='zid', handle='zone-handle')
+
+    text = provider.export_zonefile(zone)
+
+    mock_client.zones.export_zonefile.assert_called_once_with('zone-handle')
+    assert text == '$ORIGIN example.com.\n'
+
+
+# ---------------------------------------------------------------------------
+# Fehler-Mapping
+# ---------------------------------------------------------------------------
+
+def test_api_exception_wird_zu_provider_error(provider, mock_client):
+    mock_client.zones.get_all.side_effect = hcloud.APIException(
+        code=500, message='boom', details={})
+    with pytest.raises(ProviderError):
+        provider.list_zones()
+
+
+def test_403_wird_zu_auth_error(provider, mock_client):
+    mock_client.zones.get_all.side_effect = hcloud.APIException(
+        code='forbidden', message='nope', details={})
+    with pytest.raises(ProviderAuthError):
+        provider.list_zones()
+
+
+def test_404_wird_zu_not_found(provider, mock_client):
+    zone = Zone(name='example.com', id='zid', handle=object())
+    mock_client.zones.get_rrset_all.side_effect = hcloud.APIException(
+        code='not_found', message='weg', details={})
+    with pytest.raises(ProviderNotFoundError):
+        provider.get_rrsets(zone)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -60,8 +60,8 @@ def dj(data_dir, integration_config, require_api_token):
 class TestZoneSync:
 
     def test_testdomain_ist_bei_hetzner_vorhanden(self, dj, require_test_domain):
-        """Die Testdomain muss in _hetzner_zones eingetragen sein."""
-        assert require_test_domain in dj._hetzner_zones
+        """Die Testdomain muss in _zones eingetragen sein."""
+        assert require_test_domain in dj._zones
         assert require_test_domain in dj.config['domains']
 
     def test_zone_id_ist_befüllt(self, dj, require_test_domain):
@@ -172,12 +172,12 @@ $TTL 3600
 
     @staticmethod
     def _get_rrset_map(dj, domain):
-        """Liefert {(name, type): [value, ...]} der aktuellen Zone bei Hetzner."""
-        zone = dj._hetzner_zones[domain]
-        rrsets = dj.client.zones.get_rrset_all(zone)
+        """Liefert {(name, type): [value, ...]} der aktuellen Zone beim Provider."""
+        provider = dj._provider_for[domain]
+        zone = dj._zones[domain]
         return {
-            (r.name, r.type): sorted(rec.value for rec in (r.records or []))
-            for r in rrsets
+            (r.name, r.type): sorted(r.records)
+            for r in provider.get_rrsets(zone)
             if r.type != 'SOA'
         }
 
@@ -251,7 +251,7 @@ class TestCreateMissing:
 
         # Die Zone existiert bereits → create() darf nicht aufgerufen worden sein
         # (wir können das nur indirekt prüfen: Domain muss normal befüllt sein)
-        assert require_test_domain in dj._hetzner_zones
+        assert require_test_domain in dj._zones
 
 
 # ---------------------------------------------------------------------------
@@ -293,10 +293,11 @@ class TestTestdataLiveSync:
 
     @staticmethod
     def _rrset_map(dj, domain):
-        zone = dj._hetzner_zones[domain]
+        provider = dj._provider_for[domain]
+        zone = dj._zones[domain]
         return {
-            (r.name, r.type): sorted(rec.value for rec in (r.records or []))
-            for r in dj.client.zones.get_rrset_all(zone)
+            (r.name, r.type): sorted(r.records)
+            for r in provider.get_rrsets(zone)
             if r.type != 'SOA'
         }
 
@@ -336,9 +337,10 @@ class TestTestdataLiveSync:
 
         # TTL aller verwalteten Records (außer dem von Hetzner gepflegten
         # SOA/NS-Satz) muss 300s betragen.
-        zone = dj._hetzner_zones[domain]
+        provider = dj._provider_for[domain]
+        zone = dj._zones[domain]
         ttls = {
-            r.ttl for r in dj.client.zones.get_rrset_all(zone)
+            r.ttl for r in provider.get_rrsets(zone)
             if r.type not in ('SOA', 'NS')
         }
         assert ttls == {300}, f"Unerwartete TTLs bei Hetzner: {ttls}"

--- a/tests/test_multiprovider.py
+++ b/tests/test_multiprovider.py
@@ -1,0 +1,185 @@
+"""Tests für den Multiprovider-Betrieb (Ticket #10).
+
+Zwei FakeProvider mit unterschiedlichen Zonenbeständen; Domains werden je nach
+config-`provider`-Feld geroutet. Keine echten API-Aufrufe.
+"""
+import json
+
+import pytest
+
+from dnsjinja.dnsjinja import DNSJinja
+from dnsjinja.providers.base import ProviderError
+from tests.conftest import FakeProvider, install_provider_loader
+
+
+def _write_multiprovider_config(data_dir, *, providers, domains, default_provider=None):
+    glob = {
+        "zone-files": "zone-files",
+        "zone-backups": "zone-backups",
+        "templates": "templates",
+        "name-servers": ["213.133.100.98"],
+        "providers": providers,
+    }
+    if default_provider is not None:
+        glob["default-provider"] = default_provider
+    cfg = {"global": glob, "domains": domains}
+    path = data_dir / 'config' / 'config.json'
+    path.write_text(json.dumps(cfg), encoding='utf-8')
+    return path
+
+
+@pytest.fixture
+def two_providers():
+    """Zwei FakeProvider; p1 kennt a.example, p2 kennt b.example."""
+    p1 = FakeProvider(zones=['a.example'])
+    p2 = FakeProvider(zones=['b.example'])
+    p1.name = 'p1'
+    p2.name = 'p2'
+    return p1, p2
+
+
+@pytest.fixture
+def build_multi(data_dir, mock_dns_resolver, monkeypatch):
+    def _build(providers_map, *, providers, domains, default_provider=None, **kwargs):
+        path = _write_multiprovider_config(
+            data_dir, providers=providers, domains=domains,
+            default_provider=default_provider)
+        install_provider_loader(monkeypatch, lambda plugin: providers_map[plugin])
+        return DNSJinja(
+            datadir=str(data_dir), config_file=str(path),
+            auth_api_token='legacy-token', **kwargs)
+    return _build
+
+
+def test_domains_werden_pro_provider_geroutet(build_multi, two_providers):
+    p1, p2 = two_providers
+    dj = build_multi(
+        {'plugin1': p1, 'plugin2': p2},
+        providers={'p1': {'plugin': 'plugin1'}, 'p2': {'plugin': 'plugin2'}},
+        default_provider='p1',
+        domains={
+            'a.example': {'template': 'test.tpl'},
+            'b.example': {'template': 'test.tpl', 'provider': 'p2'},
+        },
+    )
+
+    assert dj._provider_for['a.example'] is p1
+    assert dj._provider_for['b.example'] is p2
+
+
+def test_list_zones_pro_provider_genau_einmal(build_multi, two_providers):
+    """Jeder Provider wird einmal nach seinen Zonen gefragt (Gruppierung)."""
+    p1, p2 = two_providers
+    build_multi(
+        {'plugin1': p1, 'plugin2': p2},
+        providers={'p1': {'plugin': 'plugin1'}, 'p2': {'plugin': 'plugin2'}},
+        default_provider='p1',
+        domains={
+            'a.example': {'template': 'test.tpl'},
+            'b.example': {'template': 'test.tpl', 'provider': 'p2'},
+        },
+    )
+
+    assert len(p1.calls_of('list_zones')) == 1
+    assert len(p2.calls_of('list_zones')) == 1
+
+
+def test_warnung_ist_provider_lokal(build_multi, two_providers, capsys):
+    """p1 darf b.example NICHT als 'nicht konfiguriert' melden (gehört zu p2)."""
+    p1, p2 = two_providers
+    build_multi(
+        {'plugin1': p1, 'plugin2': p2},
+        providers={'p1': {'plugin': 'plugin1'}, 'p2': {'plugin': 'plugin2'}},
+        default_provider='p1',
+        domains={
+            'a.example': {'template': 'test.tpl'},
+            'b.example': {'template': 'test.tpl', 'provider': 'p2'},
+        },
+    )
+
+    out = capsys.readouterr().out
+    # Keine falsche "nicht konfiguriert"-Warnung über Provider-Grenzen hinweg.
+    assert 'bitte prüfen' not in out
+
+
+def test_fehler_isolierung(build_multi, two_providers, capsys):
+    """Fällt p2 aus, bleibt a.example (p1) trotzdem voll nutzbar."""
+    p1, p2 = two_providers
+    p2.fail = {'list_zones': ProviderError('p2 down')}
+    dj = build_multi(
+        {'plugin1': p1, 'plugin2': p2},
+        providers={'p1': {'plugin': 'plugin1'}, 'p2': {'plugin': 'plugin2'}},
+        default_provider='p1',
+        domains={
+            'a.example': {'template': 'test.tpl'},
+            'b.example': {'template': 'test.tpl', 'provider': 'p2'},
+        },
+    )
+
+    assert 'a.example' in dj._provider_for
+    assert 'b.example' not in dj.config['domains']
+    assert 'nicht verfügbar' in capsys.readouterr().out
+
+
+def test_zwei_accounts_gleiches_plugin(build_multi):
+    """Zwei benannte Provider mit demselben Plugin sind getrennte Instanzen."""
+    pa = FakeProvider(zones=['a.example']); pa.name = 'acc-a'
+    pb = FakeProvider(zones=['b.example']); pb.name = 'acc-b'
+    # Loader dispatcht über token-env-unterschiedliche Definitionen via plugin-Key.
+    providers_map = {'hetzner-a': pa, 'hetzner-b': pb}
+    dj = build_multi(
+        providers_map,
+        providers={
+            'acc-a': {'plugin': 'hetzner-a'},
+            'acc-b': {'plugin': 'hetzner-b'},
+        },
+        domains={
+            'a.example': {'template': 'test.tpl', 'provider': 'acc-a'},
+            'b.example': {'template': 'test.tpl', 'provider': 'acc-b'},
+        },
+    )
+
+    assert dj._provider_for['a.example'] is pa
+    assert dj._provider_for['b.example'] is pb
+
+
+# ---------------------------------------------------------------------------
+# Config-Validierung der Provider-Referenzen
+# ---------------------------------------------------------------------------
+
+class TestProviderRefValidierung:
+
+    def _build_invalid(self, data_dir, mock_dns_resolver, **cfg_kwargs):
+        path = _write_multiprovider_config(data_dir, **cfg_kwargs)
+        with pytest.raises(SystemExit):
+            DNSJinja(datadir=str(data_dir), config_file=str(path),
+                     auth_api_token='t')
+
+    def test_unbekannter_domain_provider(self, data_dir, mock_dns_resolver):
+        self._build_invalid(
+            data_dir, mock_dns_resolver,
+            providers={'p1': {'plugin': 'plugin1'}},
+            default_provider='p1',
+            domains={'a.example': {'template': 'test.tpl', 'provider': 'gibtsnicht'}},
+        )
+
+    def test_unbekannter_default_provider(self, data_dir, mock_dns_resolver):
+        self._build_invalid(
+            data_dir, mock_dns_resolver,
+            providers={'p1': {'plugin': 'plugin1'}},
+            default_provider='nope',
+            domains={'a.example': {'template': 'test.tpl'}},
+        )
+
+    def test_domain_provider_ohne_providers_block(self, data_dir, mock_dns_resolver):
+        # provider-Feld an der Domain, aber kein global.providers
+        path = data_dir / 'config' / 'config.json'
+        path.write_text(json.dumps({
+            "global": {
+                "zone-files": "zone-files", "zone-backups": "zone-backups",
+                "templates": "templates", "name-servers": ["213.133.100.98"],
+            },
+            "domains": {"a.example": {"template": "test.tpl", "provider": "x"}},
+        }), encoding='utf-8')
+        with pytest.raises(SystemExit):
+            DNSJinja(datadir=str(data_dir), config_file=str(path), auth_api_token='t')

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,34 @@
+"""Tests für die Provider-Registry / Plugin-Discovery (Ticket #9)."""
+import pytest
+
+from dnsjinja.providers import available_plugins, load_provider
+from dnsjinja.providers.base import DnsProvider, ProviderError
+from dnsjinja.providers.hetzner import HetznerProvider
+
+
+def test_builtin_hetzner_ist_verfuegbar():
+    assert 'hetzner' in available_plugins()
+
+
+def test_load_builtin_hetzner():
+    provider = load_provider('hetzner', token='dummy-token')
+    assert isinstance(provider, HetznerProvider)
+    assert provider.name == 'hetzner'
+
+
+def test_load_per_import_pfad():
+    """Ein Provider lässt sich auch über 'modul:Klasse' laden (Override)."""
+    provider = load_provider(
+        'dnsjinja.providers.hetzner:HetznerProvider', token='dummy-token')
+    assert isinstance(provider, HetznerProvider)
+
+
+def test_unbekanntes_plugin_wirft_provider_error():
+    with pytest.raises(ProviderError) as exc:
+        load_provider('gibtsnicht', token='x')
+    assert 'gibtsnicht' in str(exc.value)
+
+
+def test_geladener_provider_ist_dnsprovider():
+    provider = load_provider('hetzner', token='dummy-token')
+    assert isinstance(provider, DnsProvider)

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1,29 +1,15 @@
 """Unit-Tests für DNSJinja.
 
-Alle Hetzner-API-Aufrufe und DNS-Abfragen sind gemockt.
-Keine Netzwerkverbindung erforderlich.
+Der DNS-Provider ist ein In-Memory-`FakeProvider` (siehe conftest); es werden
+keine echten API-Aufrufe gemacht und kein hcloud benötigt. DNS-Abfragen sind
+gemockt. Keine Netzwerkverbindung erforderlich.
 """
 import pytest
-import hcloud
-from unittest.mock import MagicMock, call
 from pathlib import Path
 
 from dnsjinja.dnsjinja import DNSJinja, UploadError
-from tests.conftest import write_config
-
-
-# ---------------------------------------------------------------------------
-# Hilfsfunktion
-# ---------------------------------------------------------------------------
-
-def make_dnsjinja(data_dir, config_file, mock_client, mock_dns_resolver, **kwargs):
-    """Erstellt eine DNSJinja-Instanz mit gemockten Abhängigkeiten."""
-    return DNSJinja(
-        datadir=str(data_dir),
-        config_file=str(config_file),
-        auth_api_token='test-token-unit',
-        **kwargs,
-    )
+from dnsjinja.providers.base import ProviderError
+from tests.conftest import FakeProvider, write_config
 
 
 # ---------------------------------------------------------------------------
@@ -32,94 +18,69 @@ def make_dnsjinja(data_dir, config_file, mock_client, mock_dns_resolver, **kwarg
 
 class TestPrepareZones:
 
-    def test_bekannte_domain_wird_befüllt(self, data_dir, config_file, mock_client, mock_dns_resolver):
-        """Domains, die bei Hetzner vorhanden sind, werden korrekt in _hetzner_zones eingetragen."""
-        dj = make_dnsjinja(data_dir, config_file, mock_client, mock_dns_resolver)
+    def test_bekannte_domain_wird_befüllt(self, make_dj, config_file):
+        """Beim Provider vorhandene Domains landen in _zones / _provider_for."""
+        provider = FakeProvider(zones=['example.com'])
+        dj = make_dj(config_file, provider=provider)
 
-        assert 'example.com' in dj._hetzner_zones
-        assert dj.config['domains']['example.com']['zone-id'] == 'test-zone-id-123'
+        assert 'example.com' in dj._zones
+        assert 'example.com' in dj._provider_for
+        assert dj.config['domains']['example.com']['zone-id'] == 'id-example.com'
         assert dj.config['domains']['example.com']['zone-file'] == 'example.com.zone'
 
-    def test_fehlende_domain_wird_ignoriert(self, data_dir, mock_client, mock_dns_resolver, capsys):
-        """Domain in config aber nicht bei Hetzner → Warnung + aus config entfernt."""
+    def test_fehlende_domain_wird_ignoriert(self, make_dj, data_dir, capsys):
+        """Domain in config aber nicht beim Provider → Warnung + aus config entfernt."""
         config_path = write_config(data_dir, ['nicht-vorhanden.de'])
+        provider = FakeProvider(zones=[])  # keine Zonen
 
-        dj = make_dnsjinja(data_dir, config_path, mock_client, mock_dns_resolver)
+        dj = make_dj(config_path, provider=provider)
 
         assert 'nicht-vorhanden.de' not in dj.config['domains']
         out = capsys.readouterr().out
         assert 'nicht-vorhanden.de' in out
         assert 'ignoriert' in out
 
-    def test_create_missing_legt_zone_an(self, data_dir, mock_client, mock_dns_resolver, capsys):
-        """Mit --create-missing wird eine fehlende Domain bei Hetzner angelegt."""
+    def test_create_missing_legt_zone_an(self, make_dj, data_dir, capsys):
+        """Mit --create-missing wird eine fehlende Domain beim Provider angelegt."""
         config_path = write_config(data_dir, ['neu-anlegen.de'])
+        provider = FakeProvider(zones=[])
 
-        new_zone = MagicMock()
-        new_zone.name = 'neu-anlegen.de'
-        new_zone.id = 'new-zone-id-456'
-        create_resp = MagicMock()
-        create_resp.zone = new_zone
-        mock_client.zones.create.return_value = create_resp
+        dj = make_dj(config_path, provider=provider, create_missing=True)
 
-        dj = make_dnsjinja(
-            data_dir, config_path, mock_client, mock_dns_resolver,
-            create_missing=True,
-        )
-
-        mock_client.zones.create.assert_called_once_with(name='neu-anlegen.de', mode='primary')
-        assert 'neu-anlegen.de' in dj._hetzner_zones
-        assert dj._hetzner_zones['neu-anlegen.de'] is new_zone
+        assert provider.calls_of('create_zone') == [('create_zone', 'neu-anlegen.de')]
+        assert 'neu-anlegen.de' in dj._zones
         assert 'angelegt' in capsys.readouterr().out
 
-    def test_create_missing_api_fehler_wird_ignoriert(
-        self, data_dir, mock_client, mock_dns_resolver, capsys
-    ):
+    def test_create_missing_api_fehler_wird_ignoriert(self, make_dj, data_dir, capsys):
         """Schlägt das Anlegen fehl, wird die Domain mit Meldung übersprungen."""
         config_path = write_config(data_dir, ['fehler.de'])
-        mock_client.zones.create.side_effect = hcloud.APIException(
-            code=422, message='API-Fehler', details={}
-        )
+        provider = FakeProvider(zones=[], fail={'create_zone': ProviderError('API-Fehler')})
 
-        dj = make_dnsjinja(
-            data_dir, config_path, mock_client, mock_dns_resolver,
-            create_missing=True,
-        )
+        dj = make_dj(config_path, provider=provider, create_missing=True)
 
         assert 'fehler.de' not in dj.config['domains']
-        out = capsys.readouterr().out
-        assert 'nicht angelegt' in out
+        assert 'nicht angelegt' in capsys.readouterr().out
 
-    def test_unbekannte_hetzner_domain_gibt_warnung(
-        self, data_dir, config_file, mock_client, mock_dns_resolver, capsys
-    ):
-        """Zones, die bei Hetzner aber nicht in der Config stehen, erzeugen eine Warnung."""
-        extra_zone = MagicMock()
-        extra_zone.name = 'unbekannt.de'
-        extra_zone.id = 'extra-id'
-        mock_client.zones.get_all.return_value = [
-            mock_client.zones.get_all.return_value[0],  # example.com
-            extra_zone,
-        ]
+    def test_unbekannte_provider_domain_gibt_warnung(self, make_dj, config_file, capsys):
+        """Zonen beim Provider, die nicht in der Config stehen, erzeugen eine Warnung."""
+        provider = FakeProvider(zones=['example.com', 'unbekannt.de'])
 
-        make_dnsjinja(data_dir, config_file, mock_client, mock_dns_resolver)
+        make_dj(config_file, provider=provider)
 
         out = capsys.readouterr().out
         assert 'unbekannt.de' in out
         assert 'prüfen' in out
 
-    def test_mehrere_domains_gleichzeitig(self, data_dir, mock_client, mock_dns_resolver):
+    def test_mehrere_domains_gleichzeitig(self, make_dj, data_dir):
         """Mehrere Domains werden alle korrekt befüllt."""
-        zone_a = MagicMock(); zone_a.name = 'a.de'; zone_a.id = 'id-a'
-        zone_b = MagicMock(); zone_b.name = 'b.de'; zone_b.id = 'id-b'
-        mock_client.zones.get_all.return_value = [zone_a, zone_b]
-
         config_path = write_config(data_dir, ['a.de', 'b.de'])
-        dj = make_dnsjinja(data_dir, config_path, mock_client, mock_dns_resolver)
+        provider = FakeProvider(zones=['a.de', 'b.de'])
 
-        assert dj.config['domains']['a.de']['zone-id'] == 'id-a'
-        assert dj.config['domains']['b.de']['zone-id'] == 'id-b'
-        assert len(dj._hetzner_zones) == 2
+        dj = make_dj(config_path, provider=provider)
+
+        assert dj.config['domains']['a.de']['zone-id'] == 'id-a.de'
+        assert dj.config['domains']['b.de']['zone-id'] == 'id-b.de'
+        assert len(dj._zones) == 2
 
 
 # ---------------------------------------------------------------------------
@@ -128,71 +89,53 @@ class TestPrepareZones:
 
 class TestUploadZone:
 
-    def test_upload_erfolgreich(self, data_dir, config_file, mock_client, mock_dns_resolver, capsys):
-        """Erfolgreicher Upload gibt Bestätigungsmeldung aus."""
-        dj = make_dnsjinja(data_dir, config_file, mock_client, mock_dns_resolver, upload=True)
+    def test_upload_erfolgreich(self, make_dj, config_file, capsys):
+        """Erfolgreicher Upload legt das NS-RRSet an (SOA wird übersprungen)."""
+        provider = FakeProvider(zones=['example.com'])
+        dj = make_dj(config_file, provider=provider, upload=True)
 
         dj.upload_zone('example.com')
 
-        mock_client.zones.get_rrset_all.assert_called_once_with(
-            dj._hetzner_zones['example.com'],
-        )
-        # NS-RRSet wird erstellt (SOA wird übersprungen)
-        mock_client.zones.create_rrset.assert_called_once()
-        create_kwargs = mock_client.zones.create_rrset.call_args
-        assert create_kwargs.kwargs['name'] == '@'
-        assert create_kwargs.kwargs['type'] == 'NS'
+        assert provider.calls_of('get_rrsets') == [('get_rrsets', 'example.com')]
+        creates = provider.calls_of('create_rrset')
+        assert len(creates) == 1
+        # ('create_rrset', zone, name, type, ttl, records)
+        assert creates[0][2] == '@'
+        assert creates[0][3] == 'NS'
         assert 'erfolgreich aktualisiert' in capsys.readouterr().out
 
-    def test_upload_fehler_wirft_exception_und_schreibt_exitcode(
-        self, data_dir, config_file, mock_client, mock_dns_resolver
-    ):
-        """Bei Upload-Fehler wird UploadError geworfen und Exit-Code 254 geschrieben."""
-        mock_client.zones.get_rrset_all.side_effect = hcloud.APIException(
-            code=500, message='Verbindungsfehler', details={}
-        )
-        dj = make_dnsjinja(data_dir, config_file, mock_client, mock_dns_resolver, upload=True)
+    def test_upload_fehler_wirft_exception_und_schreibt_exitcode(self, make_dj, config_file):
+        """Bei Provider-Fehler wird UploadError geworfen und Exit-Code 254 geschrieben."""
+        provider = FakeProvider(zones=['example.com'],
+                                fail={'get_rrsets': ProviderError('Verbindungsfehler')})
+        dj = make_dj(config_file, provider=provider, upload=True)
 
         with pytest.raises(UploadError):
             dj.upload_zone('example.com')
 
         assert dj.exit_status_file.read_text(encoding='utf-8') == '254'
 
-    def test_upload_zones_setzt_bei_fehler_fort(
-        self, data_dir, mock_client, mock_dns_resolver, capsys
-    ):
+    def test_upload_zones_setzt_bei_fehler_fort(self, make_dj, data_dir, capsys):
         """upload_zones() bricht bei einer fehlerhaften Domain nicht ab."""
-        zone_a = MagicMock(); zone_a.name = 'ok.de'; zone_a.id = 'id-ok'
-        zone_b = MagicMock(); zone_b.name = 'fail.de'; zone_b.id = 'id-fail'
-        mock_client.zones.get_all.return_value = [zone_a, zone_b]
-
-        call_count = 0
-
-        def get_rrset_side_effect(zone, **kwargs):
-            nonlocal call_count
-            call_count += 1
-            if zone.name == 'fail.de':
-                raise hcloud.APIException(code=500, message='Fehler', details={})
-            return []
-
-        mock_client.zones.get_rrset_all.side_effect = get_rrset_side_effect
         config_path = write_config(data_dir, ['ok.de', 'fail.de'])
-        dj = make_dnsjinja(data_dir, config_path, mock_client, mock_dns_resolver, upload=True)
+        provider = FakeProvider(zones=['ok.de', 'fail.de'], fail_zones=['fail.de'])
+        dj = make_dj(config_path, provider=provider, upload=True)
 
         dj.upload_zones()
 
-        assert call_count == 2
-        assert 'erfolgreich aktualisiert' in capsys.readouterr().out
+        # Trotz Fehler bei fail.de wird ok.de erfolgreich verarbeitet (kein Abbruch).
+        out = capsys.readouterr().out
+        assert 'ok.de wurde bei fake erfolgreich aktualisiert' in out
+        assert 'fail.de konnte nicht aktualisiert werden' in out
 
-    def test_upload_zones_deaktiviert_tut_nichts(
-        self, data_dir, config_file, mock_client, mock_dns_resolver
-    ):
-        """upload_zones() ohne --upload macht keine API-Aufrufe."""
-        dj = make_dnsjinja(data_dir, config_file, mock_client, mock_dns_resolver, upload=False)
+    def test_upload_zones_deaktiviert_tut_nichts(self, make_dj, config_file):
+        """upload_zones() ohne --upload macht keine Provider-Aufrufe."""
+        provider = FakeProvider(zones=['example.com'])
+        dj = make_dj(config_file, provider=provider, upload=False)
 
         dj.upload_zones()
 
-        mock_client.zones.get_rrset_all.assert_not_called()
+        assert provider.calls_of('get_rrsets') == []
 
 
 # ---------------------------------------------------------------------------
@@ -201,53 +144,59 @@ class TestUploadZone:
 
 class TestBackupZone:
 
-    def test_backup_schreibt_datei(self, data_dir, config_file, mock_client, mock_dns_resolver):
-        """Backup schreibt den Inhalt der Zone in eine Datei im backup-Verzeichnis."""
-        dj = make_dnsjinja(data_dir, config_file, mock_client, mock_dns_resolver, backup=True)
+    def test_backup_schreibt_datei(self, make_dj, config_file, data_dir):
+        """Backup schreibt den Zonefile-Export in eine Datei im backup-Verzeichnis."""
+        provider = FakeProvider(zones=['example.com'],
+                                export_text='$ORIGIN example.com.\n$TTL 3600\n')
+        dj = make_dj(config_file, provider=provider, backup=True)
 
         dj.backup_zone('example.com')
 
-        mock_client.zones.export_zonefile.assert_called_once_with(
-            dj._hetzner_zones['example.com']
-        )
+        assert provider.calls_of('export_zonefile') == [('export_zonefile', 'example.com')]
         backups = list((data_dir / 'zone-backups').iterdir())
         assert len(backups) == 1
         assert 'example.com.zone' in backups[0].name
         assert '$ORIGIN example.com.' in backups[0].read_text(encoding='utf-8')
 
-    def test_backup_dateiname_enthält_serial(
-        self, data_dir, config_file, mock_client, mock_dns_resolver
-    ):
+    def test_backup_dateiname_enthält_serial(self, make_dj, config_file, data_dir):
         """Der Dateiname des Backups enthält den SOA-Zähler (2026020101)."""
-        dj = make_dnsjinja(data_dir, config_file, mock_client, mock_dns_resolver, backup=True)
+        provider = FakeProvider(zones=['example.com'])
+        dj = make_dj(config_file, provider=provider, backup=True)
 
         dj.backup_zone('example.com')
 
         backups = list((data_dir / 'zone-backups').iterdir())
         assert backups[0].name == 'example.com.zone.2026020101'
 
-    def test_backup_api_fehler_gibt_meldung_aus(
-        self, data_dir, config_file, mock_client, mock_dns_resolver, capsys
-    ):
-        """Bei Backup-Fehler wird eine Fehlermeldung ausgegeben, keine Exception geworfen."""
-        mock_client.zones.export_zonefile.side_effect = hcloud.APIException(
-            code=500, message='Netzwerkfehler', details={}
-        )
-        dj = make_dnsjinja(data_dir, config_file, mock_client, mock_dns_resolver, backup=True)
+    def test_backup_api_fehler_gibt_meldung_aus(self, make_dj, config_file, capsys):
+        """Bei Backup-Fehler wird eine Fehlermeldung ausgegeben, keine Exception."""
+        provider = FakeProvider(zones=['example.com'],
+                                fail={'export_zonefile': ProviderError('Netzwerkfehler')})
+        dj = make_dj(config_file, provider=provider, backup=True)
 
         dj.backup_zone('example.com')  # darf nicht werfen
 
         assert 'nicht gesichert' in capsys.readouterr().out
 
-    def test_backup_zones_deaktiviert_tut_nichts(
-        self, data_dir, config_file, mock_client, mock_dns_resolver
-    ):
-        """backup_zones() ohne --backup macht keine API-Aufrufe."""
-        dj = make_dnsjinja(data_dir, config_file, mock_client, mock_dns_resolver, backup=False)
+    def test_backup_ohne_export_support_wird_uebersprungen(self, make_dj, config_file, capsys, data_dir):
+        """Provider ohne Zonefile-Export überspringt das Backup sauber (kein Crash)."""
+        provider = FakeProvider(zones=['example.com'], supports_export=False)
+        dj = make_dj(config_file, provider=provider, backup=True)
+
+        dj.backup_zone('example.com')
+
+        assert provider.calls_of('export_zonefile') == []
+        assert 'übersprungen' in capsys.readouterr().out
+        assert list((data_dir / 'zone-backups').iterdir()) == []
+
+    def test_backup_zones_deaktiviert_tut_nichts(self, make_dj, config_file):
+        """backup_zones() ohne --backup macht keine Provider-Aufrufe."""
+        provider = FakeProvider(zones=['example.com'])
+        dj = make_dj(config_file, provider=provider, backup=False)
 
         dj.backup_zones()
 
-        mock_client.zones.export_zonefile.assert_not_called()
+        assert provider.calls_of('export_zonefile') == []
 
 
 # ---------------------------------------------------------------------------
@@ -256,9 +205,9 @@ class TestBackupZone:
 
 class TestWriteZoneFiles:
 
-    def test_write_erzeugt_datei(self, data_dir, config_file, mock_client, mock_dns_resolver):
+    def test_write_erzeugt_datei(self, make_dj, config_file, data_dir):
         """write_zone_files() schreibt das gerenderte Zone-File."""
-        dj = make_dnsjinja(data_dir, config_file, mock_client, mock_dns_resolver, write_zone=True)
+        dj = make_dj(config_file, write_zone=True)
 
         dj.write_zone_files()
 
@@ -268,11 +217,9 @@ class TestWriteZoneFiles:
         content = files[0].read_text(encoding='utf-8')
         assert '$ORIGIN example.com.' in content
 
-    def test_write_deaktiviert_erzeugt_keine_datei(
-        self, data_dir, config_file, mock_client, mock_dns_resolver
-    ):
+    def test_write_deaktiviert_erzeugt_keine_datei(self, make_dj, config_file, data_dir):
         """write_zone_files() ohne --write schreibt keine Dateien."""
-        dj = make_dnsjinja(data_dir, config_file, mock_client, mock_dns_resolver, write_zone=False)
+        dj = make_dj(config_file, write_zone=False)
 
         dj.write_zone_files()
 
@@ -285,79 +232,58 @@ class TestWriteZoneFiles:
 
 class TestZoneSerial:
 
-    def test_serial_selber_tag_wird_inkrementiert(
-        self, data_dir, config_file, mock_client, mock_dns_resolver
-    ):
+    def test_serial_selber_tag_wird_inkrementiert(self, make_dj, config_file):
         """Am selben Tag wird der Zähler erhöht: 2026020101 → 2026020102."""
-        dj = make_dnsjinja(data_dir, config_file, mock_client, mock_dns_resolver)
-        dj._today = '20260201'  # Gleicher Tag wie SOA-Präfix
+        dj = make_dj(config_file)
+        dj._today = '20260201'
 
-        serial = dj._new_zone_serial('example.com')
+        assert dj._new_zone_serial('example.com') == '2026020102'
 
-        assert serial == '2026020102'
-
-    def test_serial_neuer_tag_beginnt_bei_01(
-        self, data_dir, config_file, mock_client, mock_dns_resolver
-    ):
+    def test_serial_neuer_tag_beginnt_bei_01(self, make_dj, config_file):
         """An einem neuen Tag beginnt der Zähler bei 01."""
-        dj = make_dnsjinja(data_dir, config_file, mock_client, mock_dns_resolver)
-        dj._today = '20260215'  # Anderer Tag als SOA-Präfix (20260201)
+        dj = make_dj(config_file)
+        dj._today = '20260215'
 
-        serial = dj._new_zone_serial('example.com')
+        assert dj._new_zone_serial('example.com') == '2026021501'
 
-        assert serial == '2026021501'
-
-    def test_serial_format_yyyymmddnn(
-        self, data_dir, config_file, mock_client, mock_dns_resolver
-    ):
+    def test_serial_format_yyyymmddnn(self, make_dj, config_file):
         """Der Zähler hat immer das Format JJJJMMTTNN (10 Zeichen)."""
-        dj = make_dnsjinja(data_dir, config_file, mock_client, mock_dns_resolver)
+        dj = make_dj(config_file)
         dj._today = '20260201'
 
         serial = dj._new_zone_serial('example.com')
-
         assert len(serial) == 10
         assert serial.isdigit()
 
-    def test_serial_ueberlauf_bei_suffix_99_bricht_ab(
-        self, data_dir, config_file, mock_client, mock_dns_resolver
-    ):
+    def test_serial_ueberlauf_bei_suffix_99_bricht_ab(self, make_dj, config_file, mock_dns_resolver):
         """Bei Suffix 99 wird sys.exit(1) ausgelöst statt einer 11-stelligen Serial."""
-        dj = make_dnsjinja(data_dir, config_file, mock_client, mock_dns_resolver)
+        dj = make_dj(config_file)
 
-        # Mock überschreiben: aktueller Zähler endet auf 99
+        from unittest.mock import MagicMock
         soa_99 = MagicMock()
         soa_99.serial = 2026020199
         mock_dns_resolver.resolve.return_value = [soa_99]
-
-        dj._today = '20260201'  # gleicher Tag wie Serial-Präfix → Inkrement wird versucht
+        dj._today = '20260201'
 
         with pytest.raises(SystemExit) as exc_info:
             dj._new_zone_serial('example.com')
         assert exc_info.value.code == 1
 
-    def test_serial_wird_in_serials_gecacht(
-        self, data_dir, config_file, mock_client, mock_dns_resolver
-    ):
+    def test_serial_wird_in_serials_gecacht(self, make_dj, config_file):
         """_create_zone_data() speichert den berechneten Serial in self._serials."""
-        dj = make_dnsjinja(data_dir, config_file, mock_client, mock_dns_resolver)
+        dj = make_dj(config_file)
 
         assert 'example.com' in dj._serials
         assert len(dj._serials['example.com']) == 10
 
-    def test_write_zone_files_nutzt_gecachten_serial(
-        self, data_dir, config_file, mock_client, mock_dns_resolver
-    ):
+    def test_write_zone_files_nutzt_gecachten_serial(self, make_dj, config_file, mock_dns_resolver, data_dir):
         """write_zone_files() verwendet den gecachten Serial – kein zweiter DNS-Aufruf."""
-        dj = make_dnsjinja(data_dir, config_file, mock_client, mock_dns_resolver, write_zone=True)
+        dj = make_dj(config_file, write_zone=True)
         dns_calls_after_init = mock_dns_resolver.resolve.call_count
 
         dj.write_zone_files()
 
-        # Kein weiterer DNS-Aufruf durch write_zone_files()
         assert mock_dns_resolver.resolve.call_count == dns_calls_after_init
-
-        # Dateiname enthält denselben Serial wie der Dateiinhalt
         files = list((data_dir / 'zone-files').iterdir())
         serial_in_name = files[0].name.split('.')[-1]
         assert serial_in_name == dj._serials['example.com']
@@ -369,10 +295,8 @@ class TestZoneSerial:
 
 class TestTokenUndPfad:
 
-    def test_kein_token_bricht_mit_exit_1_ab(
-        self, data_dir, config_file, mock_client, mock_dns_resolver, capsys
-    ):
-        """Ohne API-Token bricht __init__ frühzeitig mit sys.exit(1) ab."""
+    def test_kein_token_bricht_mit_exit_1_ab(self, data_dir, config_file, mock_dns_resolver, capsys):
+        """Ohne API-Token (Single-Provider) bricht __init__ mit sys.exit(1) ab."""
         with pytest.raises(SystemExit) as exc_info:
             DNSJinja(
                 datadir=str(data_dir),
@@ -382,28 +306,24 @@ class TestTokenUndPfad:
         assert exc_info.value.code == 1
         assert 'API-Token' in capsys.readouterr().out
 
-    def test_config_datei_statt_verzeichnis_bricht_ab(
-        self, data_dir, mock_client, mock_dns_resolver, capsys
-    ):
+    def test_config_datei_statt_verzeichnis_bricht_ab(self, data_dir, mock_dns_resolver):
         """Wenn config_file ein Verzeichnis ist (nicht eine Datei), endet init mit exit(1)."""
         with pytest.raises(SystemExit) as exc_info:
             DNSJinja(
                 datadir=str(data_dir),
-                config_file=str(data_dir / 'config'),  # Verzeichnis statt Datei
+                config_file=str(data_dir / 'config'),
                 auth_api_token='test-token',
             )
         assert exc_info.value.code == 1
 
 
 # ---------------------------------------------------------------------------
-# Schema-Validierung (3.3)
+# Schema-Validierung
 # ---------------------------------------------------------------------------
 
 class TestConfigValidierung:
 
-    def test_config_ohne_template_schlaegt_fehl(
-        self, data_dir, mock_client, mock_dns_resolver
-    ):
+    def test_config_ohne_template_schlaegt_fehl(self, data_dir, mock_dns_resolver):
         """Config ohne Pflichtfeld 'template' wird vom Schema abgewiesen."""
         import json
         config_path = data_dir / 'config' / 'config.json'
@@ -414,7 +334,7 @@ class TestConfigValidierung:
                 "templates": "templates",
                 "name-servers": ["213.133.100.98"],
             },
-            "domains": {"test.com": {}},   # kein 'template'
+            "domains": {"test.com": {}},
         }), encoding='utf-8')
         with pytest.raises(SystemExit) as exc_info:
             DNSJinja(datadir=str(data_dir), config_file=str(config_path),
@@ -423,16 +343,14 @@ class TestConfigValidierung:
 
 
 # ---------------------------------------------------------------------------
-# Template-Rendering (3.4)
+# Template-Rendering
 # ---------------------------------------------------------------------------
 
 class TestZoneRendering:
 
-    def test_template_variablen_werden_substituiert(
-        self, data_dir, config_file, mock_client, mock_dns_resolver
-    ):
+    def test_template_variablen_werden_substituiert(self, make_dj, config_file):
         """domain und soa_serial werden korrekt ins Zone-File gerendert."""
-        dj = make_dnsjinja(data_dir, config_file, mock_client, mock_dns_resolver)
+        dj = make_dj(config_file)
         zone = dj.zones['example.com']
         assert '$ORIGIN example.com.' in zone
         assert dj._serials['example.com'] in zone
@@ -443,7 +361,7 @@ class TestZoneRendering:
 # ---------------------------------------------------------------------------
 
 class TestParseZoneRRSets:
-    """Apex-CNAME-Ziele dürfen nicht zu '@' kollabieren (Hetzner lehnt das ab)."""
+    """Apex-CNAME-Ziele dürfen nicht zu '@' kollabieren."""
 
     APEX_CNAME_ZONE = (
         "$ORIGIN example.com.\n"
@@ -455,40 +373,28 @@ class TestParseZoneRRSets:
         "www IN CNAME external.example.org.\n"
     )
 
-    def _parse(self, data_dir, config_file, mock_client, mock_dns_resolver):
-        dj = make_dnsjinja(data_dir, config_file, mock_client, mock_dns_resolver)
+    def _parse(self, make_dj, config_file):
+        dj = make_dj(config_file)
         dj.zones['example.com'] = self.APEX_CNAME_ZONE
         return dj._parse_zone_rrsets('example.com')
 
-    def test_apex_cname_ziel_wird_als_fqdn_ausgegeben(
-        self, data_dir, config_file, mock_client, mock_dns_resolver
-    ):
-        """CNAME aufs Apex -> FQDN 'example.com.', NICHT '@'."""
-        result = self._parse(data_dir, config_file, mock_client, mock_dns_resolver)
+    def test_apex_cname_ziel_wird_als_fqdn_ausgegeben(self, make_dj, config_file):
+        result = self._parse(make_dj, config_file)
         ttl, records = result[('kai', 'CNAME')]
         assert records == ['example.com.']
 
-    def test_within_zone_ziel_wird_als_fqdn_ausgegeben(
-        self, data_dir, config_file, mock_client, mock_dns_resolver
-    ):
-        """Relatives Within-Zone-Ziel -> 'verify.example.com.', nicht 'verify'."""
-        result = self._parse(data_dir, config_file, mock_client, mock_dns_resolver)
+    def test_within_zone_ziel_wird_als_fqdn_ausgegeben(self, make_dj, config_file):
+        result = self._parse(make_dj, config_file)
         _, records = result[('join', 'CNAME')]
         assert records == ['verify.example.com.']
 
-    def test_externes_ziel_bleibt_unveraendert(
-        self, data_dir, config_file, mock_client, mock_dns_resolver
-    ):
-        """Externe FQDN-Ziele bleiben identisch (keine Regression)."""
-        result = self._parse(data_dir, config_file, mock_client, mock_dns_resolver)
+    def test_externes_ziel_bleibt_unveraendert(self, make_dj, config_file):
+        result = self._parse(make_dj, config_file)
         _, records = result[('www', 'CNAME')]
         assert records == ['external.example.org.']
 
-    def test_owner_namen_bleiben_relativ_inkl_apex(
-        self, data_dir, config_file, mock_client, mock_dns_resolver
-    ):
-        """Owner-Namen bleiben relativ; der Apex-Owner bleibt '@'."""
-        result = self._parse(data_dir, config_file, mock_client, mock_dns_resolver)
+    def test_owner_namen_bleiben_relativ_inkl_apex(self, make_dj, config_file):
+        result = self._parse(make_dj, config_file)
         owners = {name for (name, rdtype) in result}
         assert '@' in owners
         assert 'kai' in owners


### PR DESCRIPTION
Neues Backlog-Ticket mit Refactoring-Plan, um die konkrete DNS-Provider-API
(aktuell fest Hetzner/hcloud) hinter einer provider-neutralen Schnittstelle
zu entkoppeln und Provider zur Laufzeit per Plugin (Entry Points / Config)
austauschbar zu machen.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Mr6VHtJn2zBbzhCL5szc2L